### PR TITLE
Configure wasm32 build and features

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,3 +36,11 @@ jobs:
       - run: rustup component add clippy
       - name: Clippy check
         run: cargo clippy --all -- -D warnings
+
+  build-wasm:
+      name: Build wasm32 target
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - run: rustup target add wasm32-unknown-unknown
+        - run: cargo build -p galileo --target wasm32-unknown-unknown

--- a/galileo/Cargo.toml
+++ b/galileo/Cargo.toml
@@ -17,22 +17,19 @@ exclude = [
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["wgpu", "tokio", "image", "serde", "winit"]
+default = ["wgpu", "serde", "winit"]
 wgpu = ["dep:wgpu", "raw-window-handle"]
-web = ["wasm-bindgen-futures", "serde", "byte-conversion", "js-sys"]
-byte-conversion = ["serde_bytes", "js-sys"]
 geojson = ["dep:geojson", "galileo-types/geojson"]
 
 [dependencies]
 cfg-if = "1"
 async-trait = "0.1.68"
-bytemuck = { version = "1.13.1", features = ["derive"] }
+bytemuck = { version = "1.14", features = ["derive"] }
 bytes = "1.4.0"
 futures = "0.3.28"
 wgpu = { version = "0.18", optional = true }
 winit = { version ="0.29", features = ["rwh_05"], optional = true }
 log = "0.4"
-image = { version = "0.24", default-features = false, features = ["png", "jpeg"], optional = true }
 lyon = { version = "1" }
 galileo-types = { path = "../galileo-types", version = "0.1.0-alpha.0" }
 galileo-mvt = { path = "../galileo-mvt", version = "0.1.0-alpha.0" }
@@ -42,25 +39,28 @@ web-time = "0.2"
 thiserror = "1.0"
 nalgebra = "0.32"
 quick_cache = "0.4"
-serde_bytes = { version = "0.11", optional = true }
-js-sys = { version = "0.3", optional = true }
 futures-intrusive = "0.5"
 geojson = { version = "0.24", optional = true }
 raw-window-handle = { version = "0.5", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.28.2", features = ["macros", "rt", "rt-multi-thread" ], optional = true }
+tokio = { version = "1.28.2", features = ["macros", "rt", "rt-multi-thread" ] }
 maybe-sync = {  version = "0.1", features = ["sync"] }
 reqwest = "0.11.18"
 rayon = "1.8"
+image = { version = "0.24", default-features = false, features = ["png", "jpeg"]}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+bytemuck = { version = "1.14", features = ["derive", "extern_crate_alloc"] }
 console_error_panic_hook = "0.1"
 console_log = "1.0"
 wgpu = { version = "0.18", features = ["webgl"] }
-wasm-bindgen-futures = { version = "0.4", optional = true }
+wasm-bindgen-futures = { version = "0.4" }
 wasm-bindgen = "0.2"
 wasm-bindgen-derive = { version = "0.2" }
+js-sys = { version = "0.3" }
+serde = { version = "1.0", features = ["std", "derive"] }
+serde_bytes = { version = "0.11" }
 bincode = "1.3"
 serde-wasm-bindgen = "0.6"
 maybe-sync = {  version = "0.1", features = [] }

--- a/galileo/src/async_runtime/mod.rs
+++ b/galileo/src/async_runtime/mod.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "tokio")]
+#[cfg(not(target_arch = "wasm32"))]
 use maybe_sync::MaybeSend;
 use std::future::Future;
 
-#[cfg(feature = "tokio")]
+#[cfg(not(target_arch = "wasm32"))]
 pub fn spawn<T>(future: T)
 where
     T: Future + MaybeSend + 'static,
@@ -11,7 +11,7 @@ where
     tokio::spawn(future);
 }
 
-#[cfg(feature = "web")]
+#[cfg(target_arch = "wasm32")]
 pub fn spawn<T>(future: T)
 where
     T: Future + 'static,

--- a/galileo/src/error.rs
+++ b/galileo/src/error.rs
@@ -1,7 +1,7 @@
 use galileo_mvt::error::GalileoMvtError;
 use thiserror::Error;
 
-#[cfg(feature = "image")]
+#[cfg(not(target_arch = "wasm32"))]
 use image::ImageError;
 
 #[derive(Debug, Error)]
@@ -14,7 +14,7 @@ pub enum GalileoError {
     Wasm(Option<String>),
     #[error("item not found")]
     NotFound,
-    #[cfg(feature = "image")]
+    #[cfg(not(target_arch = "wasm32"))]
     #[error("image decode error: {0:?}")]
     ImageDecode(#[from] ImageError),
     #[error("{0}")]

--- a/galileo/src/galileo_map.rs
+++ b/galileo/src/galileo_map.rs
@@ -2,11 +2,9 @@ use crate::control::custom::{CustomEventHandler, EventHandler};
 use crate::control::event_processor::EventProcessor;
 use crate::control::map::MapController;
 use crate::layer::data_provider::file_cache::FileCacheController;
-use crate::layer::data_provider::url_data_provider::UrlDataProvider;
 use crate::layer::data_provider::url_image_provider::{UrlImageProvider, UrlSource};
 use crate::layer::raster_tile::RasterTileLayer;
 use crate::layer::vector_tile_layer::style::VectorTileStyle;
-use crate::layer::vector_tile_layer::tile_provider::vt_processor::VtProcessor;
 use crate::layer::vector_tile_layer::VectorTileLayer;
 use crate::layer::Layer;
 use crate::map::Map;
@@ -24,9 +22,16 @@ use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::{Window, WindowBuilder};
 
 #[cfg(not(target_arch = "wasm32"))]
+use crate::layer::data_provider::url_data_provider::UrlDataProvider;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub type VectorTileProvider =
     crate::layer::vector_tile_layer::tile_provider::rayon_provider::RayonProvider<
-        UrlDataProvider<TileIndex, VtProcessor, FileCacheController>,
+        UrlDataProvider<
+            TileIndex,
+            crate::layer::vector_tile_layer::tile_provider::vt_processor::VtProcessor,
+            FileCacheController,
+        >,
     >;
 
 #[cfg(target_arch = "wasm32")]
@@ -239,7 +244,7 @@ impl MapBuilder {
             tile_scheme.clone(),
             UrlDataProvider::new(
                 tile_source,
-                VtProcessor {},
+                crate::layer::vector_tile_layer::tile_provider::vt_processor::VtProcessor {},
                 FileCacheController::new(".tile_cache"),
             ),
         );

--- a/galileo/src/layer/feature_layer/symbol/point.rs
+++ b/galileo/src/layer/feature_layer/symbol/point.rs
@@ -1,4 +1,3 @@
-use crate::error::GalileoError;
 use crate::layer::feature_layer::symbol::Symbol;
 use crate::primitives::DecodedImage;
 use crate::render::point_paint::PointPaint;
@@ -10,8 +9,12 @@ use galileo_types::geometry::Geom;
 use galileo_types::multi_point::MultiPoint;
 use nalgebra::Vector2;
 use num_traits::AsPrimitive;
-use std::ops::Deref;
 use std::sync::Arc;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::error::GalileoError;
+#[cfg(not(target_arch = "wasm32"))]
+use std::ops::Deref;
 
 #[derive(Debug, Copy, Clone)]
 pub struct CirclePointSymbol {
@@ -53,7 +56,7 @@ pub struct ImagePointSymbol {
 }
 
 impl ImagePointSymbol {
-    #[cfg(feature = "image")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_path(path: &str, offset: Vector2<f32>, scale: f32) -> Result<Self, GalileoError> {
         use image::GenericImageView;
         let image = image::io::Reader::open(path)?.decode()?;

--- a/galileo/src/primitives.rs
+++ b/galileo/src/primitives.rs
@@ -1,6 +1,7 @@
-use std::ops::Deref;
-
+#[cfg(not(target_arch = "wasm32"))]
 use crate::error::GalileoError;
+#[cfg(not(target_arch = "wasm32"))]
+use std::ops::Deref;
 
 #[derive(Debug, Clone)]
 pub struct DecodedImage {
@@ -9,7 +10,7 @@ pub struct DecodedImage {
 }
 
 impl DecodedImage {
-    #[cfg(feature = "image")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(bytes: &[u8]) -> Result<Self, GalileoError> {
         use image::GenericImageView;
         let decoded = image::load_from_memory(bytes)?;

--- a/galileo/src/render/render_bundle/tessellating.rs
+++ b/galileo/src/render/render_bundle/tessellating.rs
@@ -935,5 +935,5 @@ pub struct ImageVertex {
     pub offset: [f32; 2],
 }
 
-#[cfg(feature = "byte-conversion")]
+#[cfg(target_arch = "wasm32")]
 pub(crate) mod serialization;

--- a/wasm_examples/raster_tiles/Cargo.toml
+++ b/wasm_examples/raster_tiles/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 winit = { version ="0.29", features = ["rwh_05"] }
-galileo = { path = "../../galileo", default-features = false, features = ["wgpu", "image", "web", "serde"] }
+galileo = { path = "../../galileo" }
 galileo-types = { path = "../../galileo-types" }
 console_error_panic_hook = "0.1"
 console_log = "1.0"


### PR DESCRIPTION
* Remove `web` feature and rely on target architecture instead for conditional compilation
* Remove `image` and `tokio` features as not needed for now
* Make wasm32 target be compiled without warnings
* Add wasm32 build to CI pipeline to check on every PR