### PR TITLE
Add egui example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,26 @@
 [workspace]
-resolver = "2"
 members = [
     "galileo",
     "galileo-mvt",
     "galileo-types",
 ]
+resolver = "2"
 
 exclude = [
+    "galileo/examples/with_egui",
     "wasm_examples/raster_tiles",
     "wasm_examples/vector_tiles",
     "wasm_examples/feature_layers",
     "wasm_examples/many_points",
     "wasm_examples/lambert",
+    "wasm_examples/with_egui",
 ]
 
 [workspace.package]
-version = "0.1.0-alpha.0"
 authors = ["Maxim Gritsenko <maxim@gritsenko.biz>"]
-edition = "2021"
-repository = "https://github.com/Maximkaaa/galileo"
-license = "MIT OR Apache-2.0"
-keywords = ["gis", "map", "rendering"]
 categories = ["science::geo"]
+edition = "2021"
+keywords = ["gis", "map", "rendering"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/Maximkaaa/galileo"
+version = "0.1.0-alpha.0"

--- a/galileo/examples/README.md
+++ b/galileo/examples/README.md
@@ -20,9 +20,9 @@
 </td>
 <td>
 
-* Create a map with one raster tile layer (OSM)
-* Set initial map position and zoom
- 
+- Create a map with one raster tile layer (OSM)
+- Set initial map position and zoom
+
 </td>
 </tr>
 <tr>
@@ -38,9 +38,9 @@
 </td>
 <td>
 
-* Create a map with one vector tile layer (MapLibre)
-* Configure layer styling with the style file
-* Get information about objects in the tiles by click
+- Create a map with one vector tile layer (MapLibre)
+- Configure layer styling with the style file
+- Get information about objects in the tiles by click
 
 </td>
 </tr>
@@ -57,11 +57,11 @@
 </td>
 <td>
 
-* Create a map with feature layers without a tile base map
-* Use symbols to set advanced styles for features based on their properties
-* Change properties of the features when hovering mouse over them
-* Modify how the features are displayed based on changed properties
-* Get information about features by click
+- Create a map with feature layers without a tile base map
+- Use symbols to set advanced styles for features based on their properties
+- Change properties of the features when hovering mouse over them
+- Modify how the features are displayed based on changed properties
+- Get information about features by click
 
 </td>
 </tr>
@@ -78,8 +78,8 @@
 </td>
 <td>
 
-* Render feature layer in Lambert Equal Area projection
-* Get and update features on cursor hover
+- Render feature layer in Lambert Equal Area projection
+- Get and update features on cursor hover
 
 </td>
 </tr>
@@ -96,7 +96,7 @@
 </td>
 <td>
 
-* Render ~3_000_000 3D points over a map
+- Render ~3_000_000 3D points over a map
 
 </td>
 </tr>
@@ -113,10 +113,10 @@
 </td>
 <td>
 
-* Read ~19_000_000 points from a LAS data set (lidar laser scanning result)
-* Render all the points without pre-grouping (to demonstrate renderer performance limits)
-* NOTE: before running the example, load the dataset. Read module-level docs in the example file.
-* NOTE 2: You probably want to run this example in `--release` mode
+- Read ~19_000_000 points from a LAS data set (lidar laser scanning result)
+- Render all the points without pre-grouping (to demonstrate renderer performance limits)
+- NOTE: before running the example, load the dataset. Read module-level docs in the example file.
+- NOTE 2: You probably want to run this example in `--release` mode
 
 </td>
 </tr>
@@ -133,9 +133,9 @@ You can generate an image yourself running this example
 </td>
 <td>
 
-* Run a map without a window
-* Load GEOJSON file to a feature layer
-* Render the map to a `.png` file
+- Run a map without a window
+- Load GEOJSON file to a feature layer
+- Render the map to a `.png` file
 
 </td>
 </tr>
@@ -152,8 +152,25 @@ You can generate an image yourself running this example
 </td>
 <td>
 
-* Load features as `geo-types` geometries using `geo-zero` crate
-* Display the features with pin images
+- Load features as `geo-types` geometries using `geo-zero` crate
+- Display the features with pin images
+
+</td>
+</tr>
+<tr>
+<td>
+
+[with_egui](./with_egui)
+
+</td>
+<td>
+
+![i](https://maximkaaa.github.io/galileo/with_egui.png)
+
+</td>
+<td>
+
+- Same as the raster tiles example, but with support for [egui](https://www.egui.rs/).
 
 </td>
 </tr>

--- a/galileo/examples/with_egui/Cargo.toml
+++ b/galileo/examples/with_egui/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+edition = "2021"
+name = "with_egui"
+version = "0.1.0"
+
+[workspace]
+
+[[bin]]
+name = "with_egui"
+
+[dependencies]
+egui = "0.25.0"
+egui-wgpu = "0.25.0"
+egui-winit = { version = "0.25.0", default-features = false }
+env_logger = { version = "0.11", default-features = false }
+galileo = { path = "../../../galileo" }
+galileo-types = { path = "../../../galileo-types" }
+wgpu = { version = "0.18", default-features = false }
+winit = { version = "0.29", default-features = false }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.0", default-features = false, features = ["full"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.egui-winit]
+features = ["clipboard", "links", "wayland", "x11"]

--- a/galileo/examples/with_egui/src/lib.rs
+++ b/galileo/examples/with_egui/src/lib.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use winit::{
+    event::{Event, KeyEvent, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::Window,
+};
+
+mod run_ui;
+mod state;
+
+pub async fn run(window: Window, event_loop: EventLoop<()>) {
+    let window = Arc::new(window);
+
+    let mut state = state::State::new(Arc::clone(&window)).await;
+
+    let _ = event_loop.run(move |event, ewlt| {
+        ewlt.set_control_flow(ControlFlow::Wait);
+
+        match event {
+            Event::AboutToWait => {
+                state.about_to_wait();
+            }
+            Event::WindowEvent {
+                ref event,
+                window_id,
+            } if window_id == state.window().id() => {
+                match event {
+                    WindowEvent::CloseRequested
+                    | WindowEvent::KeyboardInput {
+                        event:
+                            KeyEvent {
+                                logical_key:
+                                    winit::keyboard::Key::Named(winit::keyboard::NamedKey::Escape),
+                                ..
+                            },
+                        ..
+                    } => ewlt.exit(),
+                    WindowEvent::Resized(physical_size) => {
+                        state.resize(*physical_size);
+                    }
+                    WindowEvent::RedrawRequested => match state.render() {
+                        Ok(_) => {}
+                        Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                            state.resize(state.size)
+                        }
+                        Err(wgpu::SurfaceError::OutOfMemory) => ewlt.exit(),
+                        Err(wgpu::SurfaceError::Timeout) => {
+                            // Ignore timeouts.
+                        }
+                    },
+                    other => {
+                        state.handle_event(other);
+                        window.request_redraw();
+                        return;
+                    }
+                };
+                state.handle_event(event);
+                window.request_redraw();
+            }
+            _ => {}
+        }
+    });
+}

--- a/galileo/examples/with_egui/src/main.rs
+++ b/galileo/examples/with_egui/src/main.rs
@@ -1,0 +1,17 @@
+mod run_ui;
+mod state;
+
+use with_egui::run;
+
+#[tokio::main]
+async fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let event_loop = winit::event_loop::EventLoop::new().unwrap();
+    let window = winit::window::WindowBuilder::new()
+        .with_title("egui + galileo")
+        .build(&event_loop)
+        .unwrap();
+
+    run(window, event_loop).await;
+}

--- a/galileo/examples/with_egui/src/run_ui.rs
+++ b/galileo/examples/with_egui/src/run_ui.rs
@@ -1,0 +1,22 @@
+use egui::Context;
+
+#[derive(Clone, Default, Debug)]
+pub struct UiState {
+    pub name: String,
+    pub age: u32,
+}
+
+pub fn run_ui(state: &mut UiState, ui: &Context) {
+    egui::Window::new("My egui Application").show(ui, |ui| {
+        ui.horizontal(|ui| {
+            let name_label = ui.label("Your name: ");
+            ui.text_edit_singleline(&mut state.name)
+                .labelled_by(name_label.id);
+        });
+        ui.add(egui::Slider::new(&mut state.age, 0..=120).text("age"));
+        if ui.button("Increment").clicked() {
+            state.age += 1;
+        }
+        ui.label(format!("Hello '{}', age {}", state.name, state.age));
+    });
+}

--- a/galileo/examples/with_egui/src/run_ui.rs
+++ b/galileo/examples/with_egui/src/run_ui.rs
@@ -1,22 +1,42 @@
 use egui::Context;
+use galileo_types::geo::impls::point::GeoPoint2d;
+use galileo_types::geo::traits::point::GeoPoint;
 
 #[derive(Clone, Default, Debug)]
 pub struct UiState {
-    pub name: String,
-    pub age: u32,
+    pub positions: Positions,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct Positions {
+    pub pointer_position: Option<GeoPoint2d>,
+    pub map_center_position: Option<GeoPoint2d>,
 }
 
 pub fn run_ui(state: &mut UiState, ui: &Context) {
-    egui::Window::new("My egui Application").show(ui, |ui| {
-        ui.horizontal(|ui| {
-            let name_label = ui.label("Your name: ");
-            ui.text_edit_singleline(&mut state.name)
-                .labelled_by(name_label.id);
-        });
-        ui.add(egui::Slider::new(&mut state.age, 0..=120).text("age"));
-        if ui.button("Increment").clicked() {
-            state.age += 1;
+    egui::Window::new("Galileo map").show(ui, |ui| {
+        ui.label("Pointer position:");
+        if let Some(pointer_position) = state.positions.pointer_position {
+            ui.label(format!(
+                "Lat: {:.4} Lon: {:.4}",
+                pointer_position.lat(),
+                pointer_position.lon()
+            ));
+        } else {
+            ui.label("<unavaliable>");
         }
-        ui.label(format!("Hello '{}', age {}", state.name, state.age));
+
+        ui.separator();
+
+        ui.label("Map center position:");
+        if let Some(map_center_position) = state.positions.map_center_position {
+            ui.label(format!(
+                "Lat: {:.4} Lon: {:.4}",
+                map_center_position.lat(),
+                map_center_position.lon()
+            ));
+        } else {
+            ui.label("<unavaliable>");
+        }
     });
 }

--- a/galileo/examples/with_egui/src/state/egui_state.rs
+++ b/galileo/examples/with_egui/src/state/egui_state.rs
@@ -1,0 +1,112 @@
+use egui::Context;
+use egui_wgpu::renderer::ScreenDescriptor;
+use egui_wgpu::Renderer;
+
+use egui_winit::{EventResponse, State};
+use wgpu::{Device, TextureFormat};
+use winit::event::WindowEvent;
+use winit::window::Window;
+
+use super::WgpuFrame;
+
+pub struct EguiState {
+    context: Context,
+    state: State,
+    renderer: Renderer,
+}
+
+impl EguiState {
+    pub fn new(
+        device: &Device,
+        output_color_format: TextureFormat,
+        output_depth_format: Option<TextureFormat>,
+        msaa_samples: u32,
+        window: &Window,
+    ) -> EguiState {
+        let egui_context = Context::default();
+        let id = egui_context.viewport_id();
+
+        let visuals = Default::default();
+        egui_context.set_visuals(visuals);
+        egui_context.set_pixels_per_point(window.scale_factor() as f32);
+
+        let egui_state = egui_winit::State::new(egui_context.clone(), id, &window, None, None);
+
+        let egui_renderer = egui_wgpu::renderer::Renderer::new(
+            device,
+            output_color_format,
+            output_depth_format,
+            msaa_samples,
+        );
+
+        EguiState {
+            context: egui_context,
+            state: egui_state,
+            renderer: egui_renderer,
+        }
+    }
+
+    pub fn handle_event(&mut self, window: &Window, event: &WindowEvent) -> EventResponse {
+        self.state.on_window_event(window, event)
+    }
+
+    pub fn render(&mut self, wgpu_frame: &mut WgpuFrame<'_>, run_ui: impl FnOnce(&Context)) {
+        let screen_descriptor = ScreenDescriptor {
+            size_in_pixels: [wgpu_frame.size.width, wgpu_frame.size.height],
+            pixels_per_point: wgpu_frame.window.scale_factor() as f32,
+        };
+
+        self.context
+            .set_pixels_per_point(wgpu_frame.window.scale_factor() as f32);
+
+        let raw_input = self.state.take_egui_input(&wgpu_frame.window);
+        let full_output = self.context.run(raw_input, run_ui);
+
+        self.state
+            .handle_platform_output(&wgpu_frame.window, full_output.platform_output);
+
+        let paint_jobs = self
+            .context
+            .tessellate(full_output.shapes, full_output.pixels_per_point);
+
+        for (id, image_delta) in &full_output.textures_delta.set {
+            self.renderer
+                .update_texture(&wgpu_frame.device, &wgpu_frame.queue, *id, &image_delta);
+        }
+
+        self.renderer.update_buffers(
+            wgpu_frame.device,
+            wgpu_frame.queue,
+            wgpu_frame.encoder,
+            &paint_jobs,
+            &screen_descriptor,
+        );
+
+        {
+            let mut render_pass =
+                wgpu_frame
+                    .encoder
+                    .begin_render_pass(&wgpu::RenderPassDescriptor {
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &wgpu_frame.texture_view,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Load,
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        label: Some("egui render pass"),
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+
+            self.renderer
+                .render(&mut render_pass, &paint_jobs, &screen_descriptor);
+        }
+
+        for x in &full_output.textures_delta.free {
+            self.renderer.free_texture(x)
+        }
+    }
+}

--- a/galileo/examples/with_egui/src/state/galileo_state.rs
+++ b/galileo/examples/with_egui/src/state/galileo_state.rs
@@ -1,0 +1,140 @@
+use std::sync::{Arc, RwLock};
+
+use galileo::{
+    control::{event_processor::EventProcessor, map::MapController},
+    layer::data_provider::file_cache::FileCacheController,
+    render::wgpu::WgpuRenderer,
+    tile_scheme::TileIndex,
+    view::MapView,
+    winit::WinitInputHandler,
+    TileScheme,
+};
+use galileo_types::{cartesian::size::Size, latlon};
+use wgpu::{Device, Queue, Surface, SurfaceConfiguration};
+use winit::{dpi::PhysicalSize, window::Window};
+
+use super::WgpuFrame;
+
+pub struct GalileoState {
+    input_handler: WinitInputHandler,
+    event_processor: EventProcessor,
+    renderer: Arc<RwLock<WgpuRenderer>>,
+    map: Arc<RwLock<galileo::map::Map>>,
+}
+
+impl GalileoState {
+    pub fn new(
+        window: Arc<Window>,
+        device: Arc<Device>,
+        surface: Arc<Surface>,
+        queue: Arc<Queue>,
+        config: SurfaceConfiguration,
+        size: winit::dpi::PhysicalSize<u32>,
+    ) -> Self {
+        let messenger = galileo::winit::WinitMessenger::new(window);
+
+        let renderer = WgpuRenderer::create_with_surface(
+            device,
+            surface,
+            queue,
+            config,
+            Size::new(size.width, size.height),
+        );
+        let renderer = Arc::new(RwLock::new(renderer));
+
+        let input_handler = WinitInputHandler::default();
+
+        let mut event_processor = EventProcessor::default();
+        event_processor.add_handler(MapController::default());
+
+        let view = MapView::new(
+            &latlon!(37.566, 126.9784),
+            TileScheme::web(18).lod_resolution(8).unwrap(),
+        );
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let cache_controller = Some(FileCacheController::new(".tile_cache"));
+        #[cfg(target_arch = "wasm32")]
+        let cache_controller: Option<FileCacheController> = None;
+
+        let tile_source = |index: &TileIndex| {
+            format!(
+                "https://tile.openstreetmap.org/{}/{}/{}.png",
+                index.z, index.x, index.y
+            )
+        };
+
+        let tile_provider =
+            galileo::layer::data_provider::url_image_provider::UrlImageProvider::new(
+                tile_source,
+                cache_controller,
+            );
+
+        let layer = Box::new(galileo::layer::RasterTileLayer::new(
+            galileo::TileScheme::web(18),
+            tile_provider,
+            None,
+        ));
+
+        let map = Arc::new(RwLock::new(galileo::map::Map::new(
+            view,
+            vec![layer],
+            Some(messenger),
+        )));
+
+        GalileoState {
+            input_handler,
+            event_processor,
+            renderer,
+            map,
+        }
+    }
+
+    pub fn about_to_wait(&self) {
+        self.map.write().unwrap().animate();
+    }
+
+    pub fn resize(&self, size: PhysicalSize<u32>) {
+        self.renderer
+            .write()
+            .expect("poisoned lock")
+            .resize(Size::new(size.width, size.height));
+        self.map
+            .write()
+            .expect("poisoned lock")
+            .set_size(Size::new(size.width as f64, size.height as f64));
+    }
+
+    pub fn render(&self, wgpu_frame: &WgpuFrame<'_>) {
+        let cast: Arc<RwLock<dyn galileo::render::Renderer>> = self.renderer.clone();
+
+        let galileo_map = self.map.read().unwrap();
+        galileo_map.load_layers(&cast);
+
+        self.renderer
+            .write()
+            .expect("poisoned lock")
+            .render_to_texture_view(&galileo_map, wgpu_frame.texture_view);
+    }
+
+    pub fn handle_event(&mut self, event: &winit::event::WindowEvent) {
+        // Phone emulator in browsers works funny with scaling, using this code fixes it.
+        // But my real phone works fine without it, so it's commented out for now, and probably
+        // should be deleted later, when we know that it's not needed on any devices.
+
+        // #[cfg(target_arch = "wasm32")]
+        // let scale = window.scale_factor();
+        //
+        // #[cfg(not(target_arch = "wasm32"))]
+        let scale = 1.0;
+
+        if let Some(raw_event) = self.input_handler.process_user_input(event, scale) {
+            let mut map = self.map.write().expect("poisoned lock");
+            self.event_processor.handle(
+                raw_event,
+                &mut map,
+                &(*self.renderer.read().expect("poisoned lock")),
+            );
+        }
+    }
+}

--- a/galileo/examples/with_egui/src/state/mod.rs
+++ b/galileo/examples/with_egui/src/state/mod.rs
@@ -147,6 +147,8 @@ impl State {
     }
 
     pub fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
+        self.ui_state.positions = self.galileo_state.positions();
+
         let texture = self.surface.get_current_texture()?;
 
         let texture_view = texture.texture.create_view(&wgpu::TextureViewDescriptor {

--- a/galileo/examples/with_egui/src/state/mod.rs
+++ b/galileo/examples/with_egui/src/state/mod.rs
@@ -1,0 +1,191 @@
+use std::{iter, sync::Arc};
+
+use crate::run_ui::{run_ui, UiState};
+
+use wgpu::TextureView;
+use winit::{event::*, window::Window};
+
+use self::{egui_state::EguiState, galileo_state::GalileoState};
+
+mod egui_state;
+mod galileo_state;
+
+pub struct WgpuFrame<'frame> {
+    device: &'frame wgpu::Device,
+    queue: &'frame wgpu::Queue,
+    encoder: &'frame mut wgpu::CommandEncoder,
+    window: &'frame Window,
+    texture_view: &'frame TextureView,
+    size: winit::dpi::PhysicalSize<u32>,
+}
+
+pub struct State {
+    pub surface: Arc<wgpu::Surface>,
+    pub device: Arc<wgpu::Device>,
+    pub queue: Arc<wgpu::Queue>,
+    pub config: wgpu::SurfaceConfiguration,
+    pub size: winit::dpi::PhysicalSize<u32>,
+    pub window: Arc<Window>,
+    pub egui_state: EguiState,
+    pub galileo_state: GalileoState,
+    pub ui_state: UiState,
+}
+
+impl State {
+    pub async fn new(window: Arc<Window>) -> Self {
+        let size = window.inner_size();
+
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+
+        let surface = unsafe { instance.create_surface(&window) }.unwrap();
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                compatible_surface: Some(&surface),
+                force_fallback_adapter: false,
+            })
+            .await
+            .unwrap();
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: None,
+                    features: wgpu::Features::empty(),
+                    limits: if cfg!(target_arch = "wasm32") {
+                        wgpu::Limits {
+                            // NOTE(alexkirsz) These are the limits on my GPU w/ WebGPU,
+                            // but your mileage may vary.
+                            max_texture_dimension_2d: 16384,
+                            ..wgpu::Limits::downlevel_webgl2_defaults()
+                        }
+                    } else {
+                        wgpu::Limits::default()
+                    },
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let surface_caps = surface.get_capabilities(&adapter);
+        let surface_format = surface_caps
+            .formats
+            .iter()
+            .copied()
+            .find(|f| f.is_srgb())
+            .unwrap_or(surface_caps.formats[0]);
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: surface_format,
+            width: size.width,
+            height: size.height,
+            present_mode: surface_caps.present_modes[0],
+            alpha_mode: surface_caps.alpha_modes[0],
+            view_formats: vec![],
+        };
+        surface.configure(&device, &config);
+
+        let egui_state = EguiState::new(&device, config.format, None, 1, &window);
+
+        let surface = Arc::new(surface);
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+
+        let galileo_state = GalileoState::new(
+            Arc::clone(&window),
+            Arc::clone(&device),
+            Arc::clone(&surface),
+            Arc::clone(&queue),
+            config.clone(),
+            size,
+        );
+
+        Self {
+            surface,
+            device,
+            queue,
+            config,
+            size,
+            window,
+            egui_state,
+            galileo_state,
+            ui_state: UiState::default(),
+        }
+    }
+
+    pub fn window(&self) -> &Window {
+        &self.window
+    }
+
+    pub fn about_to_wait(&mut self) {
+        self.galileo_state.about_to_wait();
+    }
+
+    pub fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
+        self.galileo_state.resize(new_size);
+        if new_size.width > 0 && new_size.height > 0 {
+            self.size = new_size;
+            self.config.width = new_size.width;
+            self.config.height = new_size.height;
+            self.surface.configure(&self.device, &self.config);
+        }
+    }
+
+    pub fn handle_event(&mut self, event: &WindowEvent) {
+        let res = self.egui_state.handle_event(&self.window, event);
+
+        if !res.consumed {
+            self.galileo_state.handle_event(event);
+        }
+
+        self.window().request_redraw();
+    }
+
+    pub fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
+        let texture = self.surface.get_current_texture()?;
+
+        let texture_view = texture.texture.create_view(&wgpu::TextureViewDescriptor {
+            label: None,
+            format: None,
+            dimension: None,
+            aspect: wgpu::TextureAspect::All,
+            base_mip_level: 0,
+            mip_level_count: None,
+            base_array_layer: 0,
+            array_layer_count: None,
+        });
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Render Encoder"),
+            });
+
+        {
+            let mut wgpu_frame = WgpuFrame {
+                device: &self.device,
+                queue: &self.queue,
+                encoder: &mut encoder,
+                window: &self.window,
+                texture_view: &texture_view,
+                size: self.size,
+            };
+
+            self.galileo_state.render(&wgpu_frame);
+
+            self.egui_state
+                .render(&mut wgpu_frame, |ui| run_ui(&mut self.ui_state, ui));
+        }
+
+        self.queue.submit(iter::once(encoder.finish()));
+
+        texture.present();
+
+        Ok(())
+    }
+}

--- a/galileo/src/view.rs
+++ b/galileo/src/view.rs
@@ -63,6 +63,14 @@ impl MapView {
         &self.crs
     }
 
+    pub fn position(&self) -> Option<GeoPoint2d> {
+        self.projected_position.and_then(|p| {
+            self.crs
+                .get_projection()
+                .and_then(|proj| proj.unproject(&Point2d::new(p.x, p.y)))
+        })
+    }
+
     pub fn resolution(&self) -> f64 {
         self.resolution
     }
@@ -220,6 +228,14 @@ impl MapView {
         let transformed = translation * rotation_z * p;
 
         Some(Point2::new(transformed.x, transformed.y))
+    }
+
+    pub fn screen_to_map_geo(&self, px_position: Point2d) -> Option<GeoPoint2d> {
+        self.screen_to_map(px_position).and_then(|p| {
+            self.crs
+                .get_projection()
+                .and_then(|proj| proj.unproject(&Point2d::new(p.x, p.y)))
+        })
     }
 
     pub fn translate_by_pixels(&self, from: Point2d, to: Point2d) -> Self {

--- a/wasm_examples/with_egui/Cargo.toml
+++ b/wasm_examples/with_egui/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+edition = "2021"
+name = "with_egui_wasm"
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib"]
+name = "with_egui"
+
+[dependencies]
+console_error_panic_hook = { version = "0.1", default-features = false }
+console_log = { version = "1.0", default-features = false }
+js-sys = { version = "0.3", default-features = false }
+log = { version = "0.4", default-features = false }
+wasm-bindgen = { version = "0.2", default-features = false }
+wasm-bindgen-futures = { version = "0.4", default-features = false }
+web-sys = { version = "0.3", default-features = false, features = [
+    "Document",
+    "Window",
+    "Element",
+] }
+winit = { version = "0.29", default-features = false }
+with_egui = { path = "../../galileo/examples/with_egui" }

--- a/wasm_examples/with_egui/index.html
+++ b/wasm_examples/with_egui/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>egui + galileo</title>
+</head>
+<style>
+    html, body {
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+    }
+</style>
+<body id="map">
+<script src="./pkg/with_egui.js"></script>
+<script>
+    const {init, set_style} = wasm_bindgen;
+
+    async function run_wasm() {
+        await wasm_bindgen();
+
+        init().then(() => {
+            console.log("WASM loaded");
+        })
+    }
+
+    run_wasm();
+    document.addEventListener('contextmenu', event => event.preventDefault());
+</script>
+</body>
+</html>

--- a/wasm_examples/with_egui/src/lib.rs
+++ b/wasm_examples/with_egui/src/lib.rs
@@ -1,0 +1,10 @@
+#[path = "../../common.rs"]
+mod common;
+
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen]
+pub async fn init() {
+    let (window, event_loop) = common::set_up().await;
+    with_egui::run(window, event_loop).await;
+}

--- a/wasm_examples/with_egui/vt_worker.js
+++ b/wasm_examples/with_egui/vt_worker.js
@@ -1,0 +1,16 @@
+importScripts("./pkg/with_egui.js");
+
+const { load_tile, init_vt_worker } = wasm_bindgen;
+
+async function init_worker() {
+  await wasm_bindgen("./pkg/with_egui_bg.wasm");
+
+  init_vt_worker();
+
+  self.onmessage = async (event) => {
+    let result = await load_tile(event.data);
+    self.postMessage(result, null, [result]);
+  };
+}
+
+init_worker();


### PR DESCRIPTION
Fixes #36 

This adds an example integration with egui + wgpu, running both in wasm and natively.

The egui rendering part was adapted from https://github.com/sotrh/learn-wgpu/tree/master.

In order for this to work, I had to add a way to provide external device/surface/window to the galileo renderer, as described by @Maximkaaa in #36, which meant introducing `Arc`s. A better way would be to provide these on-demand when rendering, instead of keeping references to them inside the renderer, but I'm not familiar enough with the codebase to tackle such a refactor, or even know whether it's possible.