### PR TITLE
Remove renderer from .prepare, create renderer only on Resume event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 target
 .idea
 .tile_cache
-**/pkg
+galileo/pkg
 Cargo.lock
 
 # Ignore large sample files

--- a/android_examples/raster_tiles/rust/Cargo.toml
+++ b/android_examples/raster_tiles/rust/Cargo.toml
@@ -5,17 +5,14 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
-[[bin]]
-name = "uniffi-bindgen"
-path = "src/uniffi-bindgen.rs"
-
 [dependencies]
 galileo = { path = "../../../galileo" }
 galileo-types = { path = "../../../galileo-types" }
 log = "0.4"
 tokio = {version = "1", features = ["rt-multi-thread"]}
+
+# Use this version until https://github.com/sfackler/rust-openssl/issues/2163 is fixed
 openssl-sys = "=0.9.92"
-uniffi = { version = "0.26", features = ["cli"] }
 lazy_static = "1.4"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/android_examples/raster_tiles/rust/src/uniffi-bindgen.rs
+++ b/android_examples/raster_tiles/rust/src/uniffi-bindgen.rs
@@ -1,3 +1,0 @@
-fn main() {
-    uniffi::uniffi_bindgen_main()
-}

--- a/galileo/src/layer/feature_layer/mod.rs
+++ b/galileo/src/layer/feature_layer/mod.rs
@@ -3,7 +3,7 @@ use crate::layer::feature_layer::symbol::Symbol;
 use crate::layer::Layer;
 use crate::messenger::Messenger;
 use crate::render::render_bundle::RenderBundle;
-use crate::render::{Canvas, PackedBundle, PrimitiveId, RenderOptions, Renderer};
+use crate::render::{Canvas, PackedBundle, PrimitiveId, RenderOptions};
 use crate::view::MapView;
 use galileo_types::cartesian::impls::point::{Point2d, Point3d};
 use galileo_types::cartesian::rect::Rect;
@@ -22,7 +22,7 @@ use maybe_sync::{MaybeSend, MaybeSync};
 use num_traits::AsPrimitive;
 use std::any::Any;
 use std::marker::PhantomData;
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 pub mod feature;
 pub mod symbol;
@@ -330,7 +330,7 @@ where
         self.render_internal(lod, canvas, view);
     }
 
-    fn prepare(&self, _view: &MapView, _renderer: &Arc<RwLock<dyn Renderer>>) {
+    fn prepare(&self, _view: &MapView) {
         // do nothing
     }
 
@@ -403,7 +403,7 @@ where
         self.render_internal(lod, canvas, view);
     }
 
-    fn prepare(&self, _view: &MapView, _renderer: &Arc<RwLock<dyn Renderer>>) {
+    fn prepare(&self, _view: &MapView) {
         // do nothing
     }
 
@@ -471,7 +471,7 @@ where
         self.render_internal(lod, canvas, view);
     }
 
-    fn prepare(&self, _view: &MapView, _renderer: &Arc<RwLock<dyn Renderer>>) {
+    fn prepare(&self, _view: &MapView) {
         // do nothing
     }
 

--- a/galileo/src/layer/mod.rs
+++ b/galileo/src/layer/mod.rs
@@ -1,5 +1,5 @@
 use crate::messenger::Messenger;
-use crate::render::{Canvas, Renderer};
+use crate::render::Canvas;
 use crate::view::MapView;
 use maybe_sync::{MaybeSend, MaybeSync};
 use std::any::Any;
@@ -17,7 +17,7 @@ pub use vector_tile_layer::VectorTileLayer;
 
 pub trait Layer: MaybeSend + MaybeSync {
     fn render(&self, view: &MapView, canvas: &mut dyn Canvas);
-    fn prepare(&self, view: &MapView, renderer: &Arc<RwLock<dyn Renderer>>);
+    fn prepare(&self, view: &MapView);
     fn set_messenger(&mut self, messenger: Box<dyn Messenger>);
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
@@ -28,8 +28,8 @@ impl<T: Layer + 'static> Layer for Arc<RwLock<T>> {
         self.read().unwrap().render(position, canvas)
     }
 
-    fn prepare(&self, view: &MapView, renderer: &Arc<RwLock<dyn Renderer>>) {
-        self.read().unwrap().prepare(view, renderer)
+    fn prepare(&self, view: &MapView) {
+        self.read().unwrap().prepare(view)
     }
 
     fn set_messenger(&mut self, messenger: Box<dyn Messenger>) {
@@ -55,7 +55,7 @@ impl Layer for TestLayer {
         unimplemented!()
     }
 
-    fn prepare(&self, _view: &MapView, _renderer: &Arc<RwLock<dyn Renderer>>) {
+    fn prepare(&self, _view: &MapView) {
         unimplemented!()
     }
 

--- a/galileo/src/layer/raster_tile.rs
+++ b/galileo/src/layer/raster_tile.rs
@@ -2,14 +2,14 @@ use crate::layer::data_provider::DataProvider;
 use crate::messenger::Messenger;
 use crate::primitives::DecodedImage;
 use crate::render::render_bundle::RenderBundle;
-use crate::render::{Canvas, ImagePaint, PackedBundle, PrimitiveId, RenderOptions, Renderer};
+use crate::render::{Canvas, ImagePaint, PackedBundle, PrimitiveId, RenderOptions};
 use crate::tile_scheme::{TileIndex, TileSchema};
 use crate::view::MapView;
 use maybe_sync::{MaybeSend, MaybeSync, Mutex};
 use quick_cache::sync::Cache;
 use std::any::Any;
 use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use web_time::{Duration, SystemTime};
 
 use super::Layer;
@@ -320,7 +320,7 @@ where
         *self.prev_drawn_tiles.lock() = tiles.iter().map(|(index, _)| *index).collect();
     }
 
-    fn prepare(&self, view: &MapView, _renderer: &Arc<RwLock<dyn Renderer>>) {
+    fn prepare(&self, view: &MapView) {
         if let Some(iter) = self.tile_scheme.iter_tiles(view) {
             for index in iter {
                 let tile_provider = self.tile_provider.clone();

--- a/galileo/src/layer/vector_tile_layer/tile_provider/mod.rs
+++ b/galileo/src/layer/vector_tile_layer/tile_provider/mod.rs
@@ -1,11 +1,13 @@
 use crate::layer::vector_tile_layer::style::VectorTileStyle;
 use crate::layer::vector_tile_layer::vector_tile::VectorTile;
 use crate::messenger::Messenger;
-use crate::render::Renderer;
+use crate::render::render_bundle::RenderBundle;
+use crate::render::Canvas;
 use crate::tile_scheme::TileIndex;
+use galileo_mvt::MvtTile;
 use maybe_sync::{MaybeSend, MaybeSync};
 use quick_cache::unsync::Cache;
-use std::sync::{Arc, MutexGuard, RwLock};
+use std::sync::MutexGuard;
 
 #[cfg(target_arch = "wasm32")]
 pub mod web_worker_provider;
@@ -16,13 +18,7 @@ pub mod rayon_provider;
 pub mod vt_processor;
 
 pub trait VectorTileProvider: MaybeSend + MaybeSync {
-    fn supports(&self, renderer: &RwLock<dyn Renderer>) -> bool;
-    fn load_tile(
-        &self,
-        index: TileIndex,
-        style: &VectorTileStyle,
-        renderer: &Arc<RwLock<dyn Renderer>>,
-    );
+    fn load_tile(&self, index: TileIndex, style: &VectorTileStyle);
     fn update_style(&self);
     fn read(&self) -> LockedTileStore;
     fn set_messenger(&self, messenger: Box<dyn Messenger>);
@@ -33,18 +29,62 @@ pub struct LockedTileStore<'a> {
 }
 
 impl<'a> LockedTileStore<'a> {
-    pub fn get_tile(&'a self, index: TileIndex) -> Option<&'a VectorTile> {
+    pub fn get_mvt_tile(&'a self, index: TileIndex) -> Option<&'a MvtTile> {
         self.guard.get(&index).and_then(|v| match v {
-            TileState::Loaded(tile) | TileState::Updating(tile, _) => Some(tile),
+            TileState::Loaded(tile) => Some(&tile.mvt_tile),
+            TileState::Packed(tile) | TileState::Updating(tile) | TileState::Outdated(tile) => {
+                Some(&tile.mvt_tile)
+            }
             _ => None,
         })
     }
+
+    pub fn pack(&mut self, index: TileIndex, canvas: &dyn Canvas) {
+        if self.needs_packing(&index) {
+            let tile_state = self.guard.remove(&index);
+            match tile_state {
+                Some((_, TileState::Loaded(tile))) => {
+                    let UnpackedVectorTile { bundle, mvt_tile } = *tile;
+                    let packed = canvas.pack_bundle(&bundle);
+                    self.guard.insert(
+                        index,
+                        TileState::Packed(VectorTile {
+                            mvt_tile,
+                            bundle: packed,
+                        }),
+                    );
+                }
+                _ => {
+                    log::error!("Tried to pack a tile in not packable state");
+                }
+            }
+        }
+    }
+
+    pub fn get_tile(&'a self, index: TileIndex) -> Option<&'a VectorTile> {
+        self.guard.get(&index).and_then(|v| match v {
+            TileState::Packed(tile) => Some(tile),
+            _ => None,
+        })
+    }
+
+    fn needs_packing(&self, index: &TileIndex) -> bool {
+        self.guard
+            .get(index)
+            .is_some_and(|tile_state| matches!(tile_state, TileState::Loaded(_)))
+    }
 }
 
-pub enum TileState {
-    Loading(Arc<RwLock<dyn Renderer>>),
-    Loaded(VectorTile),
+struct UnpackedVectorTile {
+    mvt_tile: MvtTile,
+    bundle: RenderBundle,
+}
+
+enum TileState {
+    Loading,
+    Loaded(Box<UnpackedVectorTile>),
     Outdated(VectorTile),
-    Updating(VectorTile, Arc<RwLock<dyn Renderer>>),
+    Updating(VectorTile),
+    Packed(VectorTile),
     Error,
 }

--- a/galileo/src/map/mod.rs
+++ b/galileo/src/map/mod.rs
@@ -1,10 +1,8 @@
 use crate::layer::Layer;
 use crate::map::layer_collection::LayerCollection;
 use crate::messenger::Messenger;
-use crate::render::Renderer;
 use crate::view::MapView;
 use galileo_types::cartesian::size::Size;
-use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use web_time::SystemTime;
 
@@ -66,9 +64,9 @@ impl Map {
         }
     }
 
-    pub fn load_layers(&self, renderer: &Arc<RwLock<dyn Renderer>>) {
+    pub fn load_layers(&self) {
         for layer in self.layers.iter_visible() {
-            layer.prepare(&self.view, renderer);
+            layer.prepare(&self.view);
         }
     }
 

--- a/galileo/src/render/render_bundle/mod.rs
+++ b/galileo/src/render/render_bundle/mod.rs
@@ -12,6 +12,7 @@ use tessellating::TessellatingRenderBundle;
 
 pub mod tessellating;
 
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum RenderBundle {
     Tessellating(TessellatingRenderBundle),

--- a/galileo/src/render/render_bundle/tessellating.rs
+++ b/galileo/src/render/render_bundle/tessellating.rs
@@ -25,7 +25,7 @@ use std::mem::size_of;
 use std::ops::Range;
 use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TessellatingRenderBundle {
     pub poly_tessellation: VertexBuffers<PolyVertex, u32>,
     pub points: Vec<PointInstance>,
@@ -47,7 +47,7 @@ pub struct ScreenRefVertex {
     color: [u8; 4],
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum PrimitiveInfo {
     MapRef { vertex_range: Range<usize> },
     ScreenRef { vertex_range: Range<usize> },

--- a/galileo/src/render/wgpu/mod.rs
+++ b/galileo/src/render/wgpu/mod.rs
@@ -229,6 +229,7 @@ impl WgpuRenderer {
         let (device, queue) = Self::create_device(&adapter).await;
 
         let config = Self::get_surface_configuration(&surface, &adapter, size);
+        log::info!("Configuring surface with size {size:?}");
         surface.configure(&device, &config);
 
         Some(Self::new_with_device_and_surface(
@@ -245,6 +246,7 @@ impl WgpuRenderer {
     {
         let instance = Self::create_instance();
 
+        log::info!("Creating new surface");
         let surface = match unsafe { instance.create_surface(window) } {
             Ok(s) => s,
             Err(err) => {
@@ -438,6 +440,7 @@ impl WgpuRenderer {
                 RenderTarget::Surface { config, surface } => {
                     config.width = new_size.width();
                     config.height = new_size.height();
+                    log::info!("Configuring surface with size {new_size:?}");
                     surface.configure(&self.device, config);
                 }
                 RenderTarget::Texture(texture, size) => {

--- a/wasm_examples/raster_tiles/README.md
+++ b/wasm_examples/raster_tiles/README.md
@@ -4,7 +4,7 @@ Galileo.
 
 To run this example, first build Galileo as wasm package:
 ```
-wasm-pack build --target no-modules --release galileo
+wasm-pack build --release galileo
 ```
 
 After the package is created, use `npm` and `webpack` to build and run the example:


### PR DESCRIPTION
This also fixes building wasm examples.

Relates to #37 