### PR TITLE
Moved update logic from symbols to feature layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Cargo.lock
 #Npm
 **/package-lock.json
 **/node_modules
+**/dist

--- a/galileo-types/src/cartesian/impls/polygon.rs
+++ b/galileo-types/src/cartesian/impls/polygon.rs
@@ -59,3 +59,12 @@ impl<P: GeometryType> GeometryType for Polygon<P> {
     type Type = PolygonGeometryType;
     type Space = P::Space;
 }
+
+impl<P> From<Vec<P>> for Polygon<P> {
+    fn from(value: Vec<P>) -> Self {
+        Self {
+            outer_contour: ClosedContour::new(value),
+            inner_contours: vec![],
+        }
+    }
+}

--- a/galileo/examples/las.rs
+++ b/galileo/examples/las.rs
@@ -10,12 +10,13 @@ use galileo::galileo_map::MapBuilder;
 use galileo::layer::feature_layer::feature::Feature;
 use galileo::layer::FeatureLayer;
 use galileo::render::point_paint::PointPaint;
-use galileo::render::render_bundle::RenderBundle;
-use galileo::render::PrimitiveId;
+use galileo::render::render_bundle::RenderPrimitive;
 use galileo::symbol::Symbol;
 use galileo::tile_scheme::TileSchema;
 use galileo::Color;
+use galileo_types::cartesian::impls::contour::Contour;
 use galileo_types::cartesian::impls::point::Point3d;
+use galileo_types::cartesian::impls::polygon::Polygon;
 use galileo_types::cartesian::traits::cartesian_point::CartesianPoint3d;
 use galileo_types::geo::crs::Crs;
 use galileo_types::geometry::Geom;
@@ -87,15 +88,21 @@ impl Feature for ColoredPoint {
 
 struct ColoredPointSymbol {}
 impl Symbol<ColoredPoint> for ColoredPointSymbol {
-    fn render<N: AsPrimitive<f32>, P: CartesianPoint3d<Num = N>>(
+    fn render<'a, N, P>(
         &self,
         feature: &ColoredPoint,
-        geometry: &Geom<P>,
-        bundle: &mut RenderBundle,
+        geometry: &'a Geom<P>,
         _min_resolution: f64,
-    ) -> Vec<PrimitiveId> {
+    ) -> Vec<RenderPrimitive<'a, N, P, Contour<P>, Polygon<P>>>
+    where
+        N: AsPrimitive<f32>,
+        P: CartesianPoint3d<Num = N> + Clone,
+    {
         if let Geom::Point(point) = geometry {
-            vec![bundle.add_point(point, PointPaint::dot(feature.color))]
+            vec![RenderPrimitive::new_point_ref(
+                point,
+                PointPaint::dot(feature.color),
+            )]
         } else {
             vec![]
         }

--- a/galileo/examples/many_points.rs
+++ b/galileo/examples/many_points.rs
@@ -3,11 +3,12 @@ use galileo::layer::feature_layer::feature::Feature;
 use galileo::layer::feature_layer::symbol::Symbol;
 use galileo::layer::feature_layer::FeatureLayer;
 use galileo::render::point_paint::PointPaint;
-use galileo::render::render_bundle::RenderBundle;
-use galileo::render::PrimitiveId;
+use galileo::render::render_bundle::RenderPrimitive;
 use galileo::tile_scheme::TileSchema;
 use galileo::Color;
+use galileo_types::cartesian::impls::contour::Contour;
 use galileo_types::cartesian::impls::point::Point3d;
+use galileo_types::cartesian::impls::polygon::Polygon;
 use galileo_types::cartesian::traits::cartesian_point::CartesianPoint3d;
 use galileo_types::geo::crs::Crs;
 use galileo_types::geometry::Geom;
@@ -35,15 +36,21 @@ impl Feature for ColoredPoint {
 
 struct ColoredPointSymbol {}
 impl Symbol<ColoredPoint> for ColoredPointSymbol {
-    fn render<N: AsPrimitive<f32>, P: CartesianPoint3d<Num = N>>(
+    fn render<'a, N, P>(
         &self,
         feature: &ColoredPoint,
-        geometry: &Geom<P>,
-        bundle: &mut RenderBundle,
+        geometry: &'a Geom<P>,
         _min_resolution: f64,
-    ) -> Vec<PrimitiveId> {
+    ) -> Vec<RenderPrimitive<'a, N, P, Contour<P>, Polygon<P>>>
+    where
+        N: AsPrimitive<f32>,
+        P: CartesianPoint3d<Num = N> + Clone,
+    {
         if let Geom::Point(point) = geometry {
-            vec![bundle.add_point(point, PointPaint::dot(feature.color))]
+            vec![RenderPrimitive::new_point_ref(
+                point,
+                PointPaint::dot(feature.color),
+            )]
         } else {
             vec![]
         }

--- a/galileo/examples/render_to_file.rs
+++ b/galileo/examples/render_to_file.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<()> {
     // We create a renderer without window, so it will use internal texture to render to.
     // Every time the `render` method is callled, the image is updated and can be retrieved
     // by the `get_image` method.
-    let renderer = WgpuRenderer::new_with_texture_rt(image_size).await;
+    let renderer = WgpuRenderer::new_with_texture_rt(image_size).await.unwrap();
     renderer.render(&map).unwrap();
 
     let bitmap = renderer.get_image().await.unwrap();

--- a/galileo/src/layer/feature_layer/symbol/arbitrary.rs
+++ b/galileo/src/layer/feature_layer/symbol/arbitrary.rs
@@ -1,7 +1,8 @@
-use crate::render::render_bundle::RenderBundle;
-use crate::render::PrimitiveId;
+use crate::render::render_bundle::RenderPrimitive;
 use crate::symbol::{CirclePointSymbol, SimpleContourSymbol, SimplePolygonSymbol, Symbol};
 use crate::Color;
+use galileo_types::cartesian::impls::contour::Contour;
+use galileo_types::cartesian::impls::polygon::Polygon;
 use galileo_types::cartesian::traits::cartesian_point::CartesianPoint3d;
 use galileo_types::geometry::Geom;
 use num_traits::AsPrimitive;
@@ -38,28 +39,23 @@ impl Default for ArbitraryGeometrySymbol {
 }
 
 impl<F> Symbol<F> for ArbitraryGeometrySymbol {
-    fn render<N: AsPrimitive<f32>, P: CartesianPoint3d<Num = N>>(
+    fn render<'a, N, P>(
         &self,
         feature: &F,
-        geometry: &Geom<P>,
-        bundle: &mut RenderBundle,
+        geometry: &'a Geom<P>,
         min_resolution: f64,
-    ) -> Vec<PrimitiveId> {
+    ) -> Vec<RenderPrimitive<'a, N, P, Contour<P>, Polygon<P>>>
+    where
+        N: AsPrimitive<f32>,
+        P: CartesianPoint3d<Num = N> + Clone,
+    {
         match geometry {
-            Geom::Point(_) => self.point.render(feature, geometry, bundle, min_resolution),
-            Geom::MultiPoint(_) => self.point.render(feature, geometry, bundle, min_resolution),
-            Geom::Contour(_) => self
-                .contour
-                .render(feature, geometry, bundle, min_resolution),
-            Geom::MultiContour(_) => self
-                .contour
-                .render(feature, geometry, bundle, min_resolution),
-            Geom::Polygon(_) => self
-                .polygon
-                .render(feature, geometry, bundle, min_resolution),
-            Geom::MultiPolygon(_) => self
-                .polygon
-                .render(feature, geometry, bundle, min_resolution),
+            Geom::Point(_) => self.point.render(feature, geometry, min_resolution),
+            Geom::MultiPoint(_) => self.point.render(feature, geometry, min_resolution),
+            Geom::Contour(_) => self.contour.render(feature, geometry, min_resolution),
+            Geom::MultiContour(_) => self.contour.render(feature, geometry, min_resolution),
+            Geom::Polygon(_) => self.polygon.render(feature, geometry, min_resolution),
+            Geom::MultiPolygon(_) => self.polygon.render(feature, geometry, min_resolution),
         }
     }
 }

--- a/galileo/src/layer/feature_layer/symbol/mod.rs
+++ b/galileo/src/layer/feature_layer/symbol/mod.rs
@@ -1,4 +1,3 @@
-use crate::render::PrimitiveId;
 use num_traits::AsPrimitive;
 
 pub mod arbitrary;
@@ -6,25 +5,25 @@ pub mod contour;
 pub mod point;
 pub mod polygon;
 
-use crate::render::render_bundle::RenderBundle;
+use crate::render::render_bundle::RenderPrimitive;
 pub use contour::SimpleContourSymbol;
+use galileo_types::cartesian::impls::contour::Contour;
+use galileo_types::cartesian::impls::polygon::Polygon;
 use galileo_types::cartesian::traits::cartesian_point::CartesianPoint3d;
 use galileo_types::geometry::Geom;
 pub use point::CirclePointSymbol;
 pub use polygon::SimplePolygonSymbol;
 
 pub trait Symbol<F> {
-    fn render<N: AsPrimitive<f32>, P: CartesianPoint3d<Num = N>>(
+    fn render<'a, N, P>(
         &self,
         feature: &F,
-        geometry: &Geom<P>,
-        bundle: &mut RenderBundle,
+        geometry: &'a Geom<P>,
         min_resolution: f64,
-    ) -> Vec<PrimitiveId>;
-
-    fn update(&self, _feature: &F, _renders_ids: &[PrimitiveId], _bundle: &mut RenderBundle) {
-        // provide implementation to make features editable
-    }
+    ) -> Vec<RenderPrimitive<'a, N, P, Contour<P>, Polygon<P>>>
+    where
+        N: AsPrimitive<f32>,
+        P: CartesianPoint3d<Num = N> + Clone;
 
     fn use_antialiasing(&self) -> bool {
         true

--- a/galileo/src/render/mod.rs
+++ b/galileo/src/render/mod.rs
@@ -14,9 +14,6 @@ pub mod render_bundle;
 pub struct PrimitiveId(usize);
 
 pub trait Renderer: MaybeSend + MaybeSync {
-    fn create_bundle(&self) -> RenderBundle;
-    fn pack_bundle(&self, bundle: &RenderBundle) -> Box<dyn PackedBundle>;
-
     fn as_any(&self) -> &dyn Any;
 }
 

--- a/galileo/src/render/render_bundle/tessellating/serialization.rs
+++ b/galileo/src/render/render_bundle/tessellating/serialization.rs
@@ -141,6 +141,7 @@ impl TessellatingRenderBundle {
                 .collect(),
             clip_area: bundle.clip_area.map(|v| v.into_typed_unchecked()),
             buffer_size: bundle.bundle_size,
+            vacant_ids: vec![],
         }
     }
 }

--- a/galileo/src/render/wgpu/mod.rs
+++ b/galileo/src/render/wgpu/mod.rs
@@ -104,20 +104,6 @@ impl RenderTarget {
 }
 
 impl Renderer for WgpuRenderer {
-    fn create_bundle(&self) -> RenderBundle {
-        RenderBundle::Tessellating(TessellatingRenderBundle::new())
-    }
-
-    fn pack_bundle(&self, bundle: &RenderBundle) -> Box<dyn PackedBundle> {
-        match bundle {
-            RenderBundle::Tessellating(inner) => Box::new(WgpuPackedBundle::new(
-                inner,
-                self,
-                self.render_set.as_ref().unwrap(),
-            )),
-        }
-    }
-
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -599,6 +585,10 @@ impl WgpuRenderer {
         };
 
         Size::new(size.width() as f64, size.height() as f64)
+    }
+
+    fn create_bundle(&self) -> RenderBundle {
+        RenderBundle::Tessellating(TessellatingRenderBundle::new())
     }
 }
 


### PR DESCRIPTION
This refactoring simplifies symbol logic and lays the groundwork for feature editing.

The symbols are no longer responsible for keeping track of primitive ids or to call update on primitives. Instead, a `render` call on a symbol now returns a set of `RenderPrimitive`s, which are then added to a render bundle by the feature layer.