### PR TITLE
Remove sized bound on projection

### DIFF
--- a/galileo-types/src/cartesian/impls/contour.rs
+++ b/galileo-types/src/cartesian/impls/contour.rs
@@ -39,7 +39,7 @@ impl<Point> Contour<Point> {
 
     pub fn project_points<P, Proj>(&self, projection: &Proj) -> Option<Contour<P>>
     where
-        Proj: Projection<InPoint = Point, OutPoint = P>,
+        Proj: Projection<InPoint = Point, OutPoint = P> + ?Sized,
     {
         let points = self
             .points
@@ -65,7 +65,7 @@ impl<Point> ClosedContour<Point> {
 
     pub fn project_points<P, Proj>(&self, projection: &Proj) -> Option<ClosedContour<P>>
     where
-        Proj: Projection<InPoint = Point, OutPoint = P>,
+        Proj: Projection<InPoint = Point, OutPoint = P> + ?Sized,
     {
         let points = self
             .points

--- a/galileo-types/src/contour.rs
+++ b/galileo-types/src/contour.rs
@@ -31,7 +31,7 @@ pub trait Contour {
         projection: &Proj,
     ) -> Option<crate::cartesian::impls::contour::Contour<Proj::OutPoint>>
     where
-        Proj: Projection<InPoint = Self::Point>,
+        Proj: Projection<InPoint = Self::Point> + ?Sized,
     {
         Some(crate::cartesian::impls::contour::Contour::new(
             self.iter_points()


### PR DESCRIPTION
This makes these methods usable in `Geometry::project`, which has the same `?Sized` bound on `Proj`.