### PR TITLE
Expose DecodedImage in the public API

### DIFF
--- a/galileo/src/control/event_processor.rs
+++ b/galileo/src/control/event_processor.rs
@@ -198,9 +198,7 @@ impl EventProcessor {
                 None
             }
             RawUserEvent::TouchMove(touch) => {
-                let Some(touch_info) = self.touches.iter().find(|t| t.id == touch.touch_id) else {
-                    return None;
-                };
+                let touch_info = self.touches.iter().find(|t| t.id == touch.touch_id)?;
                 let position = touch.position;
 
                 let mut events = vec![];

--- a/galileo/src/decoded_image.rs
+++ b/galileo/src/decoded_image.rs
@@ -1,15 +1,22 @@
+//! This module contains utilities for loading images to be rendered on the map.
+
 #[cfg(not(target_arch = "wasm32"))]
 use crate::error::GalileoError;
-#[cfg(not(target_arch = "wasm32"))]
-use std::ops::Deref;
 
+/// An image that has been loaded into memory.
 #[derive(Debug, Clone)]
 pub struct DecodedImage {
-    pub bytes: Vec<u8>,
-    pub dimensions: (u32, u32),
+    /// Raw bytes of the image, in RGBA order.
+    pub(crate) bytes: Vec<u8>,
+    /// Width and height of the image.
+    pub(crate) dimensions: (u32, u32),
 }
 
 impl DecodedImage {
+    /// Decode an image from a byte slice.
+    ///
+    /// Attempts to guess the format of the image from the data. Non-RGBA images
+    /// will be converted to RGBA.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn new(bytes: &[u8]) -> Result<Self, GalileoError> {
         use image::GenericImageView;
@@ -18,7 +25,7 @@ impl DecodedImage {
         let dimensions = decoded.dimensions();
 
         Ok(Self {
-            bytes: Vec::from(bytes.deref()),
+            bytes: bytes.into_vec(),
             dimensions,
         })
     }

--- a/galileo/src/decoded_image.rs
+++ b/galileo/src/decoded_image.rs
@@ -29,4 +29,25 @@ impl DecodedImage {
             dimensions,
         })
     }
+
+    /// Create a DecodedImage from a buffer of raw RGBA pixels.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_raw(
+        bytes: impl Into<Vec<u8>>,
+        width: u32,
+        height: u32,
+    ) -> Result<Self, GalileoError> {
+        let bytes = bytes.into();
+
+        if bytes.len() != 4 * width as usize * height as usize {
+            return Err(GalileoError::Generic(
+                "invalid image dimensions for buffer size".into(),
+            ));
+        }
+
+        Ok(Self {
+            bytes,
+            dimensions: (width, height),
+        })
+    }
 }

--- a/galileo/src/lib.rs
+++ b/galileo/src/lib.rs
@@ -71,7 +71,7 @@
 pub(crate) mod async_runtime;
 mod color;
 pub mod control;
-pub(crate) mod decoded_image;
+pub mod decoded_image;
 pub mod error;
 pub mod layer;
 mod lod;


### PR DESCRIPTION
The [`RenderBundle::add_image`](https://docs.rs/galileo/latest/galileo/render/render_bundle/struct.RenderBundle.html#method.add_image) method takes in a `DecodedImage`, but this struct is not exposed to the user. The only way to get a `DecodedImage` in the current API is to construct a `UrlImageProvider` and load everything through cached URLs, but if you're just looking to load a local file (similar to how the georust example uses a local icon`) then this is a bit unwieldy.

This PR makes the `DecodedImage` struct public, and adds the documentation required as it is now user-facing.

I would be open to suggestions on other ways to fix this issue, such as making `RenderBundle::add_image` take in an `image::RgbaImage` directly and remove the need for the DecodedImage struct entirely. 