### PR TITLE
Fix broken WASM examples

### DIFF
--- a/wasm_examples/feature_layers/Cargo.toml
+++ b/wasm_examples/feature_layers/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 winit = { version ="0.29", features = ["rwh_05"] }
-galileo = { path = "../../galileo", default-features = false, features = ["wgpu", "image", "web"] }
+galileo = { path = "../../galileo" }
 galileo-types = { path = "../../galileo-types" }
 serde = { version = "1.0", features = ["derive"]}
 bincode = "1.3"
@@ -25,3 +25,4 @@ web-sys = { version = "0.3", features = [
     "Window",
     "Element",
 ]}
+num-traits = "0.2.17"

--- a/wasm_examples/lambert/Cargo.toml
+++ b/wasm_examples/lambert/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 winit = { version ="0.29", features = ["rwh_05"] }
-galileo = { path = "../../galileo", default-features = false, features = ["wgpu", "image", "web", "serde"] }
+galileo = { path = "../../galileo" }
 galileo-types = { path = "../../galileo-types" }
 console_error_panic_hook = "0.1"
 console_log = "1.0"
@@ -23,3 +23,4 @@ web-sys = { version = "0.3", features = [
     "Window",
     "Element",
 ]}
+num-traits = "0.2.17"

--- a/wasm_examples/many_points/Cargo.toml
+++ b/wasm_examples/many_points/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 winit = { version ="0.29", features = ["rwh_05"] }
-galileo = { path = "../../galileo", default-features = false, features = ["wgpu", "image", "web", "serde"] }
+galileo = { path = "../../galileo" }
 galileo-types = { path = "../../galileo-types" }
 console_error_panic_hook = "0.1"
 console_log = "1.0"
@@ -21,3 +21,4 @@ web-sys = { version = "0.3", features = [
     "Window",
     "Element",
 ]}
+num-traits = "0.2.17"


### PR DESCRIPTION
A couple of the WASM examples have been broken by recent changes in this crate, mostly surrounding the removal of some of the Cargo features and a missing dependency. Additionally, `MapBuilder::with_raster_tiles` requires a JS function for the tile index -> URL mapping, so as a simple fix it now constructs a JS function in-place.