### PR TITLE
derive common traits for structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,10 @@ Cargo.lock
 # Ignore large sample files
 **/*.laz
 
-#Npm
+# Npm
 **/package-lock.json
 **/node_modules
 **/dist
+
+# ctags
+tags

--- a/galileo-types/src/cartesian/orient.rs
+++ b/galileo-types/src/cartesian/orient.rs
@@ -1,7 +1,8 @@
 use crate::cartesian::CartesianPoint2d;
+use serde::{Deserialize, Serialize};
 
 /// Orientation of a triplet of points.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Orientation {
     /// Clockwise
     Clockwise,

--- a/galileo-types/src/cartesian/rect.rs
+++ b/galileo-types/src/cartesian/rect.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
 /// Rectangle in 2d cartesian coordinate space.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd, Hash, Deserialize, Serialize)]
 pub struct Rect<N = f64> {
     x_min: N,
     y_min: N,

--- a/galileo-types/src/cartesian/size.rs
+++ b/galileo-types/src/cartesian/size.rs
@@ -1,7 +1,8 @@
 use num_traits::{FromPrimitive, NumCast};
+use serde::{Deserialize, Serialize};
 
 /// Generic size type. Size is not guaranteed to be non-negative.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd, Hash, Deserialize, Serialize)]
 pub struct Size<Num: num_traits::Num + PartialOrd + Copy + PartialEq = f64> {
     width: Num,
     height: Num,

--- a/galileo-types/src/cartesian/traits/contour.rs
+++ b/galileo-types/src/cartesian/traits/contour.rs
@@ -1,6 +1,7 @@
 use crate::cartesian::traits::cartesian_point::CartesianPoint2d;
 use crate::contour::{ClosedContour, Contour};
 use num_traits::{One, Zero};
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::Debug;
 
@@ -63,7 +64,7 @@ where
 }
 
 /// [Winding](https://en.wikipedia.org/wiki/Winding_number) direction of the contour.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Hash, Deserialize, Serialize)]
 pub enum Winding {
     /// Positive winding.
     Clockwise,

--- a/galileo-types/src/contour.rs
+++ b/galileo-types/src/contour.rs
@@ -103,6 +103,7 @@ impl<P, T: ClosedContour<Point = P>> Contour for T {
 }
 
 /// Iterator of contour points.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ContourPointsIterator<'a, P, Iter>
 where
     Iter: Iterator<Item = &'a P>,
@@ -146,6 +147,7 @@ where
 }
 
 /// Iterator of contour segements.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ContourSegmentIterator<'a, P: 'a, Iter>
 where
     Iter: Iterator<Item = &'a P>,

--- a/galileo-types/src/geo/crs.rs
+++ b/galileo-types/src/geo/crs.rs
@@ -6,14 +6,14 @@ use crate::geo::traits::projection::Projection;
 use serde::{Deserialize, Serialize};
 
 /// Coordinate reference system.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Crs {
     datum: Datum,
     projection_type: ProjectionType,
 }
 
 /// Method used for projecting coordinates.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum ProjectionType {
     /// Some method.

--- a/galileo-types/src/geo/datum.rs
+++ b/galileo-types/src/geo/datum.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Reference ellipsoid used to do calculations with geographic coordinates.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Datum {
     semimajor: f64,
     inv_flattening: f64,

--- a/galileo-types/src/geo/impls/point.rs
+++ b/galileo-types/src/geo/impls/point.rs
@@ -1,9 +1,10 @@
 use crate::geo::traits::point::{GeoPoint, NewGeoPoint};
 use crate::geo::traits::projection::Projection;
 use crate::geometry::{Geom, Geometry};
+use serde::{Deserialize, Serialize};
 
 /// 2d point on the surface of a celestial body.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub struct GeoPoint2d {
     lat: f64,
     lon: f64,

--- a/galileo-types/src/geo/impls/projection/dimensions.rs
+++ b/galileo-types/src/geo/impls/projection/dimensions.rs
@@ -1,7 +1,7 @@
 use crate::cartesian::{NewCartesianPoint2d, NewCartesianPoint3d};
 use crate::geo::traits::projection::Projection;
-use std::marker::PhantomData;
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 
 /// Projection that adds a default z-value to a 2d point. Reversed projecting drops the z-value.
 #[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd, Hash, Deserialize, Serialize)]

--- a/galileo-types/src/geo/impls/projection/dimensions.rs
+++ b/galileo-types/src/geo/impls/projection/dimensions.rs
@@ -1,8 +1,10 @@
 use crate::cartesian::{NewCartesianPoint2d, NewCartesianPoint3d};
 use crate::geo::traits::projection::Projection;
 use std::marker::PhantomData;
+use serde::{Deserialize, Serialize};
 
 /// Projection that adds a default z-value to a 2d point. Reversed projecting drops the z-value.
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd, Hash, Deserialize, Serialize)]
 pub struct AddDimensionProjection<Num, In, Out> {
     z: Num,
     phantom_in: PhantomData<In>,

--- a/galileo-types/src/geo/impls/projection/geodesy.rs
+++ b/galileo-types/src/geo/impls/projection/geodesy.rs
@@ -5,6 +5,7 @@ use geodesy::prelude::*;
 use std::marker::PhantomData;
 
 /// A projection constructed by `geodesy` crate.
+#[derive(Debug, Default)]
 pub struct GeodesyProjection<In, Out> {
     context: Minimal,
     op: OpHandle,

--- a/galileo-types/src/geo/impls/projection/web_mercator.rs
+++ b/galileo-types/src/geo/impls/projection/web_mercator.rs
@@ -3,9 +3,10 @@ use crate::geo::datum::Datum;
 use crate::geo::traits::point::NewGeoPoint;
 use crate::geo::traits::projection::Projection;
 use std::marker::PhantomData;
+use serde::{Deserialize, Serialize};
 
 /// Web Mercator projection.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct WebMercator<In, Out> {
     datum: Datum,
     phantom_in: PhantomData<In>,

--- a/galileo-types/src/geo/impls/projection/web_mercator.rs
+++ b/galileo-types/src/geo/impls/projection/web_mercator.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use serde::{Deserialize, Serialize};
 
 /// Web Mercator projection.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct WebMercator<In, Out> {
     datum: Datum,
     phantom_in: PhantomData<In>,

--- a/galileo-types/src/geo/impls/projection/web_mercator.rs
+++ b/galileo-types/src/geo/impls/projection/web_mercator.rs
@@ -2,8 +2,8 @@ use crate::cartesian::NewCartesianPoint2d;
 use crate::geo::datum::Datum;
 use crate::geo::traits::point::NewGeoPoint;
 use crate::geo::traits::projection::Projection;
-use std::marker::PhantomData;
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 
 /// Web Mercator projection.
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]

--- a/galileo-types/src/geojson/point.rs
+++ b/galileo-types/src/geojson/point.rs
@@ -4,7 +4,9 @@ use crate::geometry_type::{GeoSpace2d, GeometryType, PointGeometryType};
 use geojson::Position;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct GeoJsonPoint(Position);
 
 impl TryFrom<Position> for GeoJsonPoint {

--- a/galileo-types/src/geojson/point.rs
+++ b/galileo-types/src/geojson/point.rs
@@ -4,7 +4,7 @@ use crate::geometry_type::{GeoSpace2d, GeometryType, PointGeometryType};
 use geojson::Position;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct GeoJsonPoint(Position);
 
 impl TryFrom<Position> for GeoJsonPoint {

--- a/galileo-types/src/geojson/point.rs
+++ b/galileo-types/src/geojson/point.rs
@@ -2,7 +2,9 @@ use crate::error::GalileoTypesError;
 use crate::geo::{GeoPoint, NewGeoPoint};
 use crate::geometry_type::{GeoSpace2d, GeometryType, PointGeometryType};
 use geojson::Position;
+use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct GeoJsonPoint(Position);
 
 impl TryFrom<Position> for GeoJsonPoint {

--- a/galileo-types/src/geometry.rs
+++ b/galileo-types/src/geometry.rs
@@ -7,9 +7,11 @@ use crate::cartesian::{CartesianPoint2d, Rect};
 use crate::geo::Projection;
 use crate::geometry_type::{CartesianSpace2d, GeometryType, PointGeometryType};
 use crate::impls::{Contour, MultiContour, MultiPoint, MultiPolygon, Polygon};
+use serde::{Deserialize, Serialize};
 
 /// Enum of different geometry types. This enum implements the [`Geometry`] trait so you can use any generic geometry
 /// method without knowing a specific geometry type you are working with.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub enum Geom<P> {
     /// Point geometry.
     Point(P),

--- a/galileo-types/src/geometry_type.rs
+++ b/galileo-types/src/geometry_type.rs
@@ -26,41 +26,41 @@ pub trait GeometryType {
 }
 
 /// Point geometry marker.
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct PointGeometryType;
 
 /// Multipoint geometry marker.
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct MultiPointGeometryType;
 
 /// Contour geometry marker.
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct ContourGeometryType;
 
 /// MultiContour geometry marker.
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct MultiContourGeometryType;
 
 /// Polygon geometry marker.
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct PolygonGeometryType;
 
 /// MultiPolygon geometry marker.
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct MultiPolygonGeometryType;
 
 /// Geographic coordinate space marker.
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct GeoSpace2d;
 
 /// 2d cartesian coordinate space marker.
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct CartesianSpace2d;
 
 /// 3d cartesian coordinate space marker.
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct CartesianSpace3d;
 
 /// See [`Disambiguate`](super::disambig::Disambiguate).
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct AmbiguousSpace;

--- a/galileo-types/src/geometry_type.rs
+++ b/galileo-types/src/geometry_type.rs
@@ -1,4 +1,5 @@
 //! See documentation for [`GeometryType`] trait.
+use serde::{Deserialize, Serialize};
 
 /// This trait allows automatically implement [`Geometry`](crate::Geometry) trait for types that implement specific
 /// geometry traits (e.g. [`Polygon`](crate::Polygon) etc).
@@ -25,31 +26,41 @@ pub trait GeometryType {
 }
 
 /// Point geometry marker.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct PointGeometryType;
 
 /// Multipoint geometry marker.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct MultiPointGeometryType;
 
 /// Contour geometry marker.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct ContourGeometryType;
 
 /// MultiContour geometry marker.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct MultiContourGeometryType;
 
 /// Polygon geometry marker.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct PolygonGeometryType;
 
 /// MultiPolygon geometry marker.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct MultiPolygonGeometryType;
 
 /// Geographic coordinate space marker.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct GeoSpace2d;
 
 /// 2d cartesian coordinate space marker.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct CartesianSpace2d;
 
 /// 3d cartesian coordinate space marker.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct CartesianSpace3d;
 
 /// See [`Disambiguate`](super::disambig::Disambiguate).
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct AmbiguousSpace;

--- a/galileo-types/src/geometry_type.rs
+++ b/galileo-types/src/geometry_type.rs
@@ -26,41 +26,61 @@ pub trait GeometryType {
 }
 
 /// Point geometry marker.
-#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct PointGeometryType;
 
 /// Multipoint geometry marker.
-#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct MultiPointGeometryType;
 
 /// Contour geometry marker.
-#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct ContourGeometryType;
 
 /// MultiContour geometry marker.
-#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct MultiContourGeometryType;
 
 /// Polygon geometry marker.
-#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct PolygonGeometryType;
 
 /// MultiPolygon geometry marker.
-#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct MultiPolygonGeometryType;
 
 /// Geographic coordinate space marker.
-#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct GeoSpace2d;
 
 /// 2d cartesian coordinate space marker.
-#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct CartesianSpace2d;
 
 /// 3d cartesian coordinate space marker.
-#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct CartesianSpace3d;
 
 /// See [`Disambiguate`](super::disambig::Disambiguate).
-#[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+)]
 pub struct AmbiguousSpace;

--- a/galileo-types/src/impls/contour.rs
+++ b/galileo-types/src/impls/contour.rs
@@ -3,7 +3,7 @@ use crate::geometry_type::{ContourGeometryType, GeometryType};
 use serde::{Deserialize, Serialize};
 
 /// Simple [`crate::Contour`] implementation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct Contour<Point> {
     points: Vec<Point>,
     is_closed: bool,
@@ -61,7 +61,7 @@ impl<Point> Contour<Point> {
 }
 
 /// Closed contour implementation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct ClosedContour<Point> {
     /// Points of the contour.
     pub points: Vec<Point>,

--- a/galileo-types/src/impls/contour.rs
+++ b/galileo-types/src/impls/contour.rs
@@ -3,7 +3,7 @@ use crate::geometry_type::{ContourGeometryType, GeometryType};
 use serde::{Deserialize, Serialize};
 
 /// Simple [`crate::Contour`] implementation.
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct Contour<Point> {
     points: Vec<Point>,
     is_closed: bool,

--- a/galileo-types/src/impls/multi_contour.rs
+++ b/galileo-types/src/impls/multi_contour.rs
@@ -1,7 +1,9 @@
 use crate::geometry_type::{GeometryType, MultiContourGeometryType};
 use crate::impls::contour::Contour;
+use serde::{Deserialize, Serialize};
 
 /// A set of contours.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct MultiContour<P>(Vec<Contour<P>>);
 
 impl<P> crate::multi_contour::MultiContour for MultiContour<P> {

--- a/galileo-types/src/impls/multi_point.rs
+++ b/galileo-types/src/impls/multi_point.rs
@@ -1,6 +1,8 @@
 use crate::geometry_type::{GeometryType, MultiPointGeometryType};
+use serde::{Deserialize, Serialize};
 
 /// A set of points.
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct MultiPoint<P>(Vec<P>);
 
 impl<P> crate::multi_point::MultiPoint for MultiPoint<P> {

--- a/galileo-types/src/impls/multi_polygon.rs
+++ b/galileo-types/src/impls/multi_polygon.rs
@@ -3,7 +3,7 @@ use crate::impls::polygon::Polygon;
 use serde::{Deserialize, Serialize};
 
 /// A set of polygons.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct MultiPolygon<P> {
     /// Inner polygons.
     pub parts: Vec<Polygon<P>>,

--- a/galileo-types/src/impls/polygon.rs
+++ b/galileo-types/src/impls/polygon.rs
@@ -3,7 +3,7 @@ use crate::impls::contour::ClosedContour;
 use serde::{Deserialize, Serialize};
 
 /// Simple implementation of the [`Polygon`](crate::Polygon) trait.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize)]
 pub struct Polygon<P> {
     /// Outer contour.
     pub outer_contour: ClosedContour<P>,

--- a/galileo-types/src/segment.rs
+++ b/galileo-types/src/segment.rs
@@ -2,7 +2,7 @@ use crate::cartesian::{CartesianPoint2d, Orientation};
 use num_traits::{One, Zero};
 
 /// A strait line segment between two points.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct Segment<'a, Point>(pub &'a Point, pub &'a Point);
 
 impl<'a, P: CartesianPoint2d> Segment<'a, P> {


### PR DESCRIPTION
This pull request stems from an issue I had as a user of the library.  When I added a field of type `GeoPoint2d` to my struct, I discovered the struct could no longer by serialized or deserialized.  However, I can add a `Point2d` field to the struct without issue.  Why can `Point2d` be serialized and not `GeoPoint2d`, especially knowing both contain fields of *f64*?  My preference would be for both to be serializable.

The set of common traits that I like to see implemented on public structs in a library, when appropriate for the data type, are Debug, Default, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize and Deserialize.  Since you already have `serde` as a dependency, it makes sense to me to derive Serialize and Deserialize where possible, though I also see lots of libraries putting these derives behind a feature gate, and that approach has some appeal to me.  Another good candidate for a feature gate are the `strum` and and `strum_macros` libraries which allow you to derive EnumIter on your enums, which can come in handy.

Where the data structure does not have a natural Default or cannot be Copy, I did not try to get fancy, I just stripped it from the derive, so the only additions are derives that do not make the compiler complain.  The test suite still passes and *clippy* has no comment the changes.  Once I got started on `GeoPoint2d`, I kept going and touched up the structs where I could, including a couple structs that look like internal library housekeeping, where I can't imagine you actually need Hash, like `ContourPointsIterator`... maybe that is going too far.

There are two somewhat ancient threads I referred to for recommendations on what traits to derive for libraries.  User **vadixidav** makes the *pro* case on [reddit](https://www.reddit.com/r/rust/comments/p5vsjl/is_there_any_reason_not_to_derive_every_possible/):

> I would recommend deriving Clone, Debug, PartialEq, Eq, PartialOrd, Ord, and Hash (all where possible) if you are making a library. As pointed out by other posters, there are some exceptions. If you make a binary, I would only derive what you need and no more. If you make a library I highly recommend adding serde as an optional dependency and deriving Serialize and Deserialize as well, where applicable.

>If you make a library, you may want to explicitly not expose certain traits. I would always consider "will this prevent a totally valid usage, and is it strictly incorrect for a user to use this trait". As time has gone on, I have typically become more lenient, and I tend to only disallow API usage that could break invariants expected in my structs, so I typically always derive things like Ord if I can to support putting objects into BTreeMap, as it usually has no negative side-effects. It can be annoying when you have a float in your struct and then you cannot derive it, but you just have to accept that.

User **caleblbaker** adds the following observation that i find helpful:

> When you implement a trait you are making a statement about your type like "this type can be copied" or "this type can be converted into some serialized format like json". So don't implement a trait unless the statement that that trait represents is true for your type. In the case of derivable traits, the common situation is that if your type is able to derive the trait then the statement that the trait is making is probably true for the type. So in most cases there's nothing wrong with deriving traits that you might not be taking advantage of since you're just making true statements about your type. 

On the conservative, or *against* side, I can quote the venerable Burnt Sushi from the rust [users forum](https://users.rust-lang.org/t/what-traits-should-i-normally-derive/484/):

> Note that this advice is assuming you're developing a library and that the type in question is a public type exposed to users of your library.

> I think some good general advice is be conservative because the traits you derive on your types are part of its public interface. For example, if you derive Copy on an enum but later decide to, say, add a variant with a String in it, then you're forced to remove the impl for Copy on your type. This will be a breaking change for downstream users. This is true for any other trait, but Copy can be especially tricky because it's easy to change the definition of your type such that it can no longer be Copy.

> Being conservative is a good thing here because adding an impl to your type can never be a breaking change. (Is this true? Can someone check me on that? I think it is.) IMO, the process of adding impls "because the compiler says you needed them" is not a bad place to start. It keeps your impls to the minimum possible. If your types need more impls, then someone will hopefully come along and say, "Hey you should derive this trait on your type because such and such..." And then you can evaluate whether it's worthwhile to do so, or whether the user should just create a wrapper type and derive the impl themselves (which may not be possible if the impl requires details of the type that aren't exposed).

> Deriving Debug is probably close to a universally good thing. It's just plain convenient to allow users of your library to dump a quick 'n' dirty representation of a value. Moreover, the name of the trait itself won't give any false impressions about whether that representation should be shown to the user.

Generally I would categorize ignoring Burnt Sushi's advice to be foolish, or out on a limb.  Note that his primary concern is creating breaking changes for downstream users in the future if these derives need to be removed to accommodate additional constraints introduced by, for example, adding a new field with a more constrictive type.  As one of the users described who is coming along saying "Hey you should derive this trait", I kind of see it the other way around.  The fact that removing these derives creates fear of breaking changes implies that users are not only taking advantage of these traits, but in fact may rely on them to the extent that removing them could break their code.  This is a good thing because it enables us to use to the code in the first place to accomplish the goals of our project.