### PR TITLE
geojson fixup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build
         run: cargo build --verbose --all
       - name: Tests
-        run: cargo test --features _tests --verbose
+        run: cargo test --features _tests,geojson --verbose
 
   fmt:
     name: Rustfmt
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup component add clippy
       - name: Clippy check
-        run: cargo clippy --all -- -D warnings
+        run: cargo clippy --all --features geojson -- -D warnings
 
   build-wasm:
       name: Build wasm32 target

--- a/galileo-types/src/geojson/mod.rs
+++ b/galileo-types/src/geojson/mod.rs
@@ -30,7 +30,7 @@ impl Geometry for geojson::Geometry {
 }
 
 fn convert_contour(line_string: &LineStringType) -> Option<Contour<GeoJsonPoint>> {
-    let is_closed = line_string.len() > 0 && line_string[0] == line_string[line_string.len() - 1];
+    let is_closed = !line_string.is_empty() && line_string[0] == line_string[line_string.len() - 1];
     Some(Contour::new(
         line_string
             .iter()
@@ -40,7 +40,7 @@ fn convert_contour(line_string: &LineStringType) -> Option<Contour<GeoJsonPoint>
     ))
 }
 
-fn convert_multi_point(points: &Vec<Position>) -> Option<MultiPoint<GeoJsonPoint>> {
+fn convert_multi_point(points: &[Position]) -> Option<MultiPoint<GeoJsonPoint>> {
     Some(MultiPoint::from(
         points
             .iter()
@@ -49,11 +49,11 @@ fn convert_multi_point(points: &Vec<Position>) -> Option<MultiPoint<GeoJsonPoint
     ))
 }
 
-fn convert_multi_contour(lines: &Vec<LineStringType>) -> Option<MultiContour<GeoJsonPoint>> {
+fn convert_multi_contour(lines: &[LineStringType]) -> Option<MultiContour<GeoJsonPoint>> {
     Some(MultiContour::from(
         lines
             .iter()
-            .map(|l| convert_contour(l))
+            .map(convert_contour)
             .collect::<Option<Vec<_>>>()?,
     ))
 }
@@ -68,10 +68,10 @@ fn convert_polygon(polygon: &PolygonType) -> Option<Polygon<GeoJsonPoint>> {
     ))
 }
 
-fn convert_multi_polygon(mp: &Vec<PolygonType>) -> Option<MultiPolygon<GeoJsonPoint>> {
+fn convert_multi_polygon(mp: &[PolygonType]) -> Option<MultiPolygon<GeoJsonPoint>> {
     Some(MultiPolygon::from(
         mp.iter()
-            .map(|p| convert_polygon(p))
+            .map(convert_polygon)
             .collect::<Option<Vec<_>>>()?,
     ))
 }

--- a/galileo-types/src/geojson/mod.rs
+++ b/galileo-types/src/geojson/mod.rs
@@ -70,8 +70,6 @@ fn convert_polygon(polygon: &PolygonType) -> Option<Polygon<GeoJsonPoint>> {
 
 fn convert_multi_polygon(mp: &[PolygonType]) -> Option<MultiPolygon<GeoJsonPoint>> {
     Some(MultiPolygon::from(
-        mp.iter()
-            .map(convert_polygon)
-            .collect::<Option<Vec<_>>>()?,
+        mp.iter().map(convert_polygon).collect::<Option<Vec<_>>>()?,
     ))
 }

--- a/galileo-types/src/geojson/point.rs
+++ b/galileo-types/src/geojson/point.rs
@@ -5,7 +5,7 @@ use geojson::Position;
 use serde::{Deserialize, Serialize};
 
 #[derive(
-    Debug, Default, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, Deserialize, Serialize,
+    Debug, Default, Clone, PartialEq, PartialOrd, Deserialize, Serialize,
 )]
 pub struct GeoJsonPoint(Position);
 

--- a/galileo-types/src/geojson/point.rs
+++ b/galileo-types/src/geojson/point.rs
@@ -4,9 +4,7 @@ use crate::geometry_type::{GeoSpace2d, GeometryType, PointGeometryType};
 use geojson::Position;
 use serde::{Deserialize, Serialize};
 
-#[derive(
-    Debug, Default, Clone, PartialEq, PartialOrd, Deserialize, Serialize,
-)]
+#[derive(Debug, Default, Clone, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub struct GeoJsonPoint(Position);
 
 impl TryFrom<Position> for GeoJsonPoint {

--- a/galileo/examples/render_to_file.rs
+++ b/galileo/examples/render_to_file.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
         .max(TileSchema::web(18).lod_resolution(17).unwrap());
 
     // Create OSM layer for background
-    let cache_controller = Some(FileCacheController::new(".tile_cache"));
+    let cache_controller = FileCacheController::new(".tile_cache");
     let tile_provider = UrlImageProvider::new_cached(
         |index: &TileIndex| {
             format!(

--- a/galileo/src/layer/feature_layer/feature/geojson.rs
+++ b/galileo/src/layer/feature_layer/feature/geojson.rs
@@ -4,6 +4,8 @@ impl Feature for geojson::Feature {
     type Geom = geojson::Geometry;
 
     fn geometry(&self) -> &Self::Geom {
-        self.geometry.as_ref().expect("GeoJSON Feature has no geometry")
+        self.geometry
+            .as_ref()
+            .expect("GeoJSON Feature has no geometry")
     }
 }

--- a/galileo/src/layer/feature_layer/feature/geojson.rs
+++ b/galileo/src/layer/feature_layer/feature/geojson.rs
@@ -4,7 +4,6 @@ impl Feature for geojson::Feature {
     type Geom = geojson::Geometry;
 
     fn geometry(&self) -> &Self::Geom {
-        let res = self.geometry.as_ref().unwrap();
-        &res
+        self.geometry.as_ref().expect("GeoJSON Feature has no geometry")
     }
 }


### PR DESCRIPTION
* Remove a few derived traits introduced in #67  that can't be fulfilled by GeoJSON structs
* Activate geojson feature during CI so these compile issues aren't hidden in the future (one might want to go a step further and activate all features with the --all-features flag, but it looks like your build script demands protoc executable so that would need a tiny extra CI step)
* Fix example and clippy warnings pertaining to geojson code path.