### PR TITLE
Fix contour projection setting `Contour.is_closed` to `true` (#85)

### DIFF
--- a/galileo-types/src/contour.rs
+++ b/galileo-types/src/contour.rs
@@ -199,7 +199,10 @@ where
             .iter_points()
             .map(|p| projection.project(p))
             .collect::<Option<Vec<Proj::OutPoint>>>()?;
-        Some(Geom::Contour(crate::impls::Contour::new(points, true)))
+        Some(Geom::Contour(crate::impls::Contour::new(
+            points,
+            self.is_closed(),
+        )))
     }
 }
 


### PR DESCRIPTION
Fixes an issue where contours would always be rendered as closed when projected into another coordinate system.