### PR TITLE
Update to `wgpu 22`, `winit 0.30`

### DIFF
--- a/galileo/Cargo.toml
+++ b/galileo/Cargo.toml
@@ -32,7 +32,7 @@ async-trait = "0.1.68"
 bytemuck = { version = "1.14", features = ["derive"] }
 bytes = "1.4.0"
 futures = "0.3.28"
-winit = { version = "0.29", features = ["rwh_06"], optional = true }
+winit = { version = "0.30", features = ["rwh_06"], optional = true }
 lazy_static = "1.4"
 log = "0.4"
 lyon = { version = "1" }
@@ -55,7 +55,7 @@ rustybuzz = { version = "0.17", optional = true }
 geozero = "0.13.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-wgpu = { version = "0.19", optional = true }
+wgpu = { version = "22", optional = true }
 tokio = { version = "1.39", features = ["macros", "rt", "rt-multi-thread"] }
 maybe-sync = { version = "0.1", features = ["sync"] }
 reqwest = "0.11.18"
@@ -66,7 +66,7 @@ image = { version = "0.24", default-features = false, features = ["png", "jpeg"]
 bytemuck = { version = "1.14", features = ["derive", "extern_crate_alloc"] }
 console_error_panic_hook = "0.1"
 console_log = "1.0"
-wgpu = { version = "0.19", default-features = false, features = ["webgl", "wgsl"] }
+wgpu = { version = "22", default-features = false, features = ["webgl", "wgsl"] }
 wasm-bindgen-futures = { version = "0.4" }
 wasm-bindgen = "0.2"
 wasm-bindgen-derive = { version = "0.2" }
@@ -98,7 +98,7 @@ web-sys = { version = "0.3", features = [
 
 [target.'cfg(target_os = "android")'.dependencies]
 reqwest = { version = "0.11.18", features = ["native-tls-vendored"] }
-winit = { version = "0.29", features = ["android-native-activity"] }
+winit = { version = "0.30", features = ["android-native-activity"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/galileo/examples/with_egui/Cargo.toml
+++ b/galileo/examples/with_egui/Cargo.toml
@@ -7,18 +7,18 @@ version = "0.1.0"
 name = "with_egui"
 
 [dependencies]
-egui = "0.26"
-egui-wgpu = "0.26"
-egui-winit = { version = "0.26", default-features = false }
+egui = "0.29"
+egui-wgpu = "0.29"
+egui-winit = { version = "0.29", default-features = false }
 env_logger = { version = "0.11", default-features = false }
 galileo = { path = "../../../galileo" }
 galileo-types = { path = "../../../galileo-types" }
-wgpu = { version = "0.19", default-features = false }
-winit = { version = "0.29", default-features = false }
+wgpu = { version = "22", default-features = false }
+winit = { version = "0.30", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.0", default-features = false, features = ["full"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.egui-winit]
-version = "0.26"
+version = "0.29"
 features = ["clipboard", "links", "wayland", "x11"]

--- a/galileo/examples/with_egui/src/lib.rs
+++ b/galileo/examples/with_egui/src/lib.rs
@@ -14,6 +14,8 @@ pub async fn run(window: Window, event_loop: EventLoop<()>) {
 
     let mut state = state::State::new(Arc::clone(&window)).await;
 
+    // TODO: refactor this to use winit 0.30 approach to handle event loop
+    #[allow(deprecated)]
     let _ = event_loop.run(move |event, ewlt| {
         ewlt.set_control_flow(ControlFlow::Wait);
 

--- a/galileo/examples/with_egui/src/main.rs
+++ b/galileo/examples/with_egui/src/main.rs
@@ -3,6 +3,7 @@
 mod run_ui;
 mod state;
 
+use winit::window::Window;
 use with_egui::run;
 
 #[tokio::main]
@@ -10,9 +11,11 @@ async fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     let event_loop = winit::event_loop::EventLoop::new().unwrap();
-    let window = winit::window::WindowBuilder::new()
-        .with_title("egui + galileo")
-        .build(&event_loop)
+
+    // TODO: refactor this to use winit 0.30 approach to create windows
+    #[allow(deprecated)]
+    let window = event_loop
+        .create_window(Window::default_attributes().with_title("egui + galileo"))
         .unwrap();
 
     run(window, event_loop).await;

--- a/galileo/examples/with_egui/src/state/egui_state.rs
+++ b/galileo/examples/with_egui/src/state/egui_state.rs
@@ -56,7 +56,7 @@ impl EguiState {
         response
     }
 
-    pub fn render<'a>(&mut self, wgpu_frame: &'a mut WgpuFrame<'a>, run_ui: impl FnMut(&Context)) {
+    pub fn render(&mut self, wgpu_frame: &mut WgpuFrame, run_ui: impl FnMut(&Context)) {
         let screen_descriptor = ScreenDescriptor {
             size_in_pixels: [wgpu_frame.size.width, wgpu_frame.size.height],
             pixels_per_point: wgpu_frame.window.scale_factor() as f32,
@@ -89,8 +89,8 @@ impl EguiState {
         );
 
         {
-            let encoder = &mut wgpu_frame.encoder;
-            let mut render_pass = encoder
+            let mut render_pass = wgpu_frame
+                .encoder
                 .begin_render_pass(&wgpu::RenderPassDescriptor {
                     color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                         view: wgpu_frame.texture_view,

--- a/galileo/examples/with_egui/src/state/egui_state.rs
+++ b/galileo/examples/with_egui/src/state/egui_state.rs
@@ -30,13 +30,14 @@ impl EguiState {
         egui_context.set_visuals(visuals);
         egui_context.set_pixels_per_point(window.scale_factor() as f32);
 
-        let egui_state = State::new(egui_context.clone(), id, &window, None, None);
+        let egui_state = State::new(egui_context.clone(), id, &window, None, None, None);
 
         let egui_renderer = Renderer::new(
             device,
             output_color_format,
             output_depth_format,
             msaa_samples,
+            false,
         );
 
         EguiState {
@@ -55,7 +56,7 @@ impl EguiState {
         response
     }
 
-    pub fn render(&mut self, wgpu_frame: &mut WgpuFrame<'_>, run_ui: impl FnOnce(&Context)) {
+    pub fn render<'a>(&mut self, wgpu_frame: &'a mut WgpuFrame<'a>, run_ui: impl FnMut(&Context)) {
         let screen_descriptor = ScreenDescriptor {
             size_in_pixels: [wgpu_frame.size.width, wgpu_frame.size.height],
             pixels_per_point: wgpu_frame.window.scale_factor() as f32,
@@ -88,23 +89,23 @@ impl EguiState {
         );
 
         {
-            let mut render_pass =
-                wgpu_frame
-                    .encoder
-                    .begin_render_pass(&wgpu::RenderPassDescriptor {
-                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                            view: wgpu_frame.texture_view,
-                            resolve_target: None,
-                            ops: wgpu::Operations {
-                                load: wgpu::LoadOp::Load,
-                                store: wgpu::StoreOp::Store,
-                            },
-                        })],
-                        depth_stencil_attachment: None,
-                        label: Some("egui render pass"),
-                        timestamp_writes: None,
-                        occlusion_query_set: None,
-                    });
+            let encoder = &mut wgpu_frame.encoder;
+            let mut render_pass = encoder
+                .begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: wgpu_frame.texture_view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    label: Some("egui render pass"),
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                })
+                .forget_lifetime();
 
             self.renderer
                 .render(&mut render_pass, &paint_jobs, &screen_descriptor);

--- a/galileo/examples/with_egui/src/state/mod.rs
+++ b/galileo/examples/with_egui/src/state/mod.rs
@@ -66,6 +66,7 @@ impl State {
                     } else {
                         wgpu::Limits::default()
                     },
+                    memory_hints: Default::default(),
                 },
                 None,
             )

--- a/galileo/src/map/mod.rs
+++ b/galileo/src/map/mod.rs
@@ -130,4 +130,15 @@ impl Map {
     pub fn set_size(&mut self, new_size: Size) {
         self.view = self.view.with_size(new_size);
     }
+
+    /// Sets the new event messenger for the map.
+    pub fn set_messenger(&mut self, messenger: Option<impl Messenger + 'static>) {
+        let messenger: Option<Box<dyn Messenger>> = if let Some(m) = messenger {
+            Some(Box::new(m))
+        } else {
+            None
+        };
+
+        self.messenger = messenger;
+    }
 }

--- a/galileo/src/platform/web.rs
+++ b/galileo/src/platform/web.rs
@@ -72,9 +72,9 @@ impl PlatformService for WebPlatformService {
     }
 
     async fn load_bytes_from_url(&self, url: &str) -> Result<bytes::Bytes, GalileoError> {
-        let mut opts = RequestInit::new();
-        opts.method("GET");
-        opts.mode(RequestMode::Cors);
+        let opts = RequestInit::new();
+        opts.set_method("GET");
+        opts.set_mode(RequestMode::Cors);
 
         let request =
             Request::new_with_str_and_init(url, &opts).expect("failed to create a request object");

--- a/galileo/src/platform/web/map_builder.rs
+++ b/galileo/src/platform/web/map_builder.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use wasm_bindgen::prelude::wasm_bindgen;
 use winit::dpi::PhysicalSize;
 use winit::event_loop::EventLoop;
-use winit::window::WindowBuilder;
+use winit::window::Window;
 
 impl MapBuilder {
     /// Creates a raster tile layer.
@@ -86,15 +86,15 @@ impl MapBuilder {
             .event_loop
             .take()
             .unwrap_or_else(|| EventLoop::new().unwrap());
-        let window = self.window.take().unwrap_or_else(|| {
-            WindowBuilder::new()
-                .with_inner_size(PhysicalSize {
-                    width: 1024,
-                    height: 1024,
-                })
-                .build(&event_loop)
-                .unwrap()
-        });
+
+        // TODO: refactor to use winit v0.30 approach to creating window
+        #[allow(deprecated)]
+        let window = event_loop
+            .create_window(Window::default_attributes().with_inner_size(PhysicalSize {
+                width: 1024,
+                height: 1024,
+            }))
+            .expect("failed to create a window");
 
         let canvas = web_sys::Element::from(window.canvas().unwrap());
         container.append_child(&canvas).unwrap();

--- a/galileo/src/render/wgpu/mod.rs
+++ b/galileo/src/render/wgpu/mod.rs
@@ -351,6 +351,7 @@ impl WgpuRenderer {
                         wgpu::Limits::default()
                     },
                     label: None,
+                    memory_hints: Default::default(),
                 },
                 None,
             )

--- a/galileo/src/render/wgpu/pipelines/image.rs
+++ b/galileo/src/render/wgpu/pipelines/image.rs
@@ -174,7 +174,8 @@ impl ImagePipeline {
             render_pass.set_pipeline(&self.wgpu_pipeline);
         }
 
-        render_pass.set_bind_group(1, &buffers.texture_bind_group, &[]);
+        let bind_group: &BindGroup = &buffers.texture_bind_group;
+        render_pass.set_bind_group(1, bind_group, &[]);
         render_pass.set_vertex_buffer(0, buffers.vertex_buffer.slice(..));
         render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
         render_pass.draw_indexed(0..INDICES.len() as u32, 0, 0..1);

--- a/galileo/src/render/wgpu/pipelines/mod.rs
+++ b/galileo/src/render/wgpu/pipelines/mod.rs
@@ -150,11 +150,13 @@ fn default_pipeline_descriptor<'a>(
             module: shader,
             entry_point: "vs_main",
             buffers,
+            compilation_options: Default::default(),
         },
         fragment: Some(wgpu::FragmentState {
             module: shader,
             entry_point: "fs_main",
             targets,
+            compilation_options: Default::default(),
         }),
         primitive: wgpu::PrimitiveState {
             topology: wgpu::PrimitiveTopology::TriangleList,
@@ -183,5 +185,6 @@ fn default_pipeline_descriptor<'a>(
             alpha_to_coverage_enabled: false,
         },
         multiview: None,
+        cache: Default::default(),
     }
 }


### PR DESCRIPTION
Current version of `wgpu` is 23, but `egui` depends on `v22` so it's fine to support v22 for now. Upgrading from v22 to v23 is not difficult so we can do it whenever we need.

Fixes #91 , #89 