### PR TITLE
Fixed compile error caused by latlon macro

### DIFF
--- a/galileo-types/src/geo/impls/point.rs
+++ b/galileo-types/src/geo/impls/point.rs
@@ -64,8 +64,6 @@ impl Geometry for GeoPoint2d {
 #[macro_export]
 macro_rules! latlon {
     ($lat:expr, $lon:expr) => {
-        <::galileo_types::geo::impls::GeoPoint2d as ::galileo_types::geo::NewGeoPoint<f64>>::latlon(
-            $lat, $lon,
-        )
+        <$crate::geo::impls::GeoPoint2d as $crate::geo::NewGeoPoint<f64>>::latlon($lat, $lon)
     };
 }


### PR DESCRIPTION
Using the git version of the repo, I was trying to run the main [docs](https://docs.rs/galileo/0.1.1/galileo/index.html) example.

I got the error

```
failed to resolve: could not find `galileo_types` in the list of imported crates
  --> src/main.rs:11:17
   |
11 |         .center(latlon!(37.566, 126.9784))
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `galileo_types` in the list of imported crates
```

Looking at the macro
```rust
#[macro_export]
macro_rules! latlon {
    ($lat:expr, $lon:expr) => {
        <::galileo_types::geo::impls::GeoPoint2d as ::galileo_types::geo::NewGeoPoint<f64>>::latlon(
            $lat, $lon,
        )
    };
}
```

It seems like it is using hardcoded paths. I switched the paths to using `$crate` and the example ran normally