### PR TITLE
Fix web raster tile example

### DIFF
--- a/galileo/Cargo.toml
+++ b/galileo/Cargo.toml
@@ -18,10 +18,11 @@ crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [features]
-default = ["wgpu", "serde", "winit", "cosmic-text", "_tests", "rustybuzz"]
+default = ["wgpu", "serde", "winit", "cosmic-text", "_tests", "rustybuzz", "image"]
 wgpu = ["dep:wgpu", "raw-window-handle"]
 geojson = ["dep:geojson", "galileo-types/geojson"]
 rustybuzz = ["dep:rustybuzz"]
+image = ["dep:image"]
 
 # Used to provide some fixtures for doctests
 _tests = []
@@ -53,6 +54,7 @@ strfmt = "0.2"
 ahash = "0.8"
 rustybuzz = { version = "0.17", optional = true }
 geozero = "0.13.0"
+image = { version = "0.24", default-features = false, features = ["png", "jpeg"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 wgpu = { version = "22", optional = true }
@@ -60,7 +62,6 @@ tokio = { version = "1.39", features = ["macros", "rt", "rt-multi-thread"] }
 maybe-sync = { version = "0.1", features = ["sync"] }
 reqwest = "0.11.18"
 rayon = "1.8"
-image = { version = "0.24", default-features = false, features = ["png", "jpeg"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bytemuck = { version = "1.14", features = ["derive", "extern_crate_alloc"] }
@@ -85,6 +86,7 @@ web-sys = { version = "0.3", features = [
     "HtmlImageElement",
     "HtmlCanvasElement",
     "CanvasRenderingContext2d",
+    "ImageBitmap",
     "ImageData",
     "Request",
     "Headers",

--- a/galileo/examples/highlight_features.rs
+++ b/galileo/examples/highlight_features.rs
@@ -22,9 +22,9 @@ const GREEN_PIN: &[u8] = include_bytes!("data/pin-green.png");
 
 lazy_static! {
     static ref YELLOW_PIN_IMAGE: Arc<DecodedImage> =
-        Arc::new(DecodedImage::new(YELLOW_PIN).expect("Must have Yellow Pin Image"));
+        Arc::new(DecodedImage::decode(YELLOW_PIN).expect("Must have Yellow Pin Image"));
     static ref GREEN_PIN_IMAGE: Arc<DecodedImage> =
-        Arc::new(DecodedImage::new(GREEN_PIN).expect("Must have Green Pin Image"));
+        Arc::new(DecodedImage::decode(GREEN_PIN).expect("Must have Green Pin Image"));
 }
 
 #[tokio::main]

--- a/galileo/src/decoded_image.rs
+++ b/galileo/src/decoded_image.rs
@@ -111,7 +111,7 @@ mod serialization {
                     let mut encoded = vec![];
                     let encoder = PngEncoder::new(&mut encoded);
                     if let Err(err) = encoder.write_image(
-                        &bytes,
+                        bytes,
                         dimensions.width(),
                         dimensions.height(),
                         ColorType::Rgba8,

--- a/galileo/src/decoded_image.rs
+++ b/galileo/src/decoded_image.rs
@@ -2,12 +2,7 @@
 
 use crate::error::GalileoError;
 
-#[cfg(not(target_arch = "wasm32"))]
-use base64::prelude::BASE64_STANDARD;
-#[cfg(not(target_arch = "wasm32"))]
-use base64::Engine;
-#[cfg(not(target_arch = "wasm32"))]
-use image::ImageEncoder;
+use galileo_types::cartesian::Size;
 
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -15,11 +10,16 @@ use std::fmt::Formatter;
 
 /// An image that has been loaded into memory.
 #[derive(Debug, Clone)]
-pub struct DecodedImage {
-    /// Raw bytes of the image, in RGBA order.
-    pub(crate) bytes: Vec<u8>,
-    /// Width and height of the image.
-    pub(crate) dimensions: (u32, u32),
+pub struct DecodedImage(pub(crate) DecodedImageType);
+
+#[derive(Debug, Clone)]
+pub(crate) enum DecodedImageType {
+    Bitmap {
+        bytes: Vec<u8>,
+        dimensions: Size<u32>,
+    },
+    #[cfg(target_arch = "wasm32")]
+    JsImageBitmap(web_sys::ImageBitmap),
 }
 
 impl DecodedImage {
@@ -27,121 +27,145 @@ impl DecodedImage {
     ///
     /// Attempts to guess the format of the image from the data. Non-RGBA images
     /// will be converted to RGBA.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn new(bytes: &[u8]) -> Result<Self, GalileoError> {
+    #[cfg(feature = "image")]
+    pub fn decode(bytes: &[u8]) -> Result<Self, GalileoError> {
         use image::GenericImageView;
         let decoded = image::load_from_memory(bytes).map_err(|_| GalileoError::ImageDecode)?;
         let bytes = decoded.to_rgba8();
         let dimensions = decoded.dimensions();
 
-        Ok(Self {
+        Ok(Self(DecodedImageType::Bitmap {
             bytes: bytes.into_vec(),
-            dimensions,
-        })
+            dimensions: Size::new(dimensions.0, dimensions.1),
+        }))
     }
 
     /// Create a DecodedImage from a buffer of raw RGBA pixels.
     // #[cfg(not(target_arch = "wasm32"))]
     pub fn from_raw(
         bytes: impl Into<Vec<u8>>,
-        width: u32,
-        height: u32,
+        dimensions: Size<u32>,
     ) -> Result<Self, GalileoError> {
         let bytes = bytes.into();
 
-        if bytes.len() != 4 * width as usize * height as usize {
+        if bytes.len() != 4 * dimensions.width() as usize * dimensions.height() as usize {
             return Err(GalileoError::Generic(
                 "invalid image dimensions for buffer size".into(),
             ));
         }
 
-        Ok(Self {
-            bytes,
-            dimensions: (width, height),
-        })
-    }
-
-    /// Return binary data of the image.
-    pub fn bytes(&self) -> &[u8] {
-        &self.bytes
+        Ok(Self(DecodedImageType::Bitmap { bytes, dimensions }))
     }
 
     /// Return width of the image in pixels.
     pub fn width(&self) -> u32 {
-        self.dimensions.0
+        self.0.width()
     }
 
     /// Return height of the image in pixels.
     pub fn height(&self) -> u32 {
-        self.dimensions.1
+        self.0.height()
+    }
+
+    /// Bitmap size in bytes
+    pub fn size(&self) -> usize {
+        self.width() as usize * self.height() as usize * 4
     }
 }
 
-impl Serialize for DecodedImage {
-    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        cfg_if::cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
-                panic!("shall not be used in WASM")
-            } else {
-                use image::ColorType;
-                use image::codecs::png::PngEncoder;
+impl DecodedImageType {
+    fn width(&self) -> u32 {
+        match self {
+            DecodedImageType::Bitmap { dimensions, .. } => dimensions.width(),
+            #[cfg(target_arch = "wasm32")]
+            DecodedImageType::JsImageBitmap(image_bitmap) => image_bitmap.width(),
+        }
+    }
 
-                let mut encoded = vec![];
-                let encoder = PngEncoder::new(&mut encoded);
-                if let Err(err) = encoder.write_image(
-                    &self.bytes,
-                    self.dimensions.0,
-                    self.dimensions.1,
-                    ColorType::Rgba8,
-                ) {
-                    return Err(serde::ser::Error::custom(format!(
-                        "failed to encode image to PNG: {err}"
-                    )));
-                }
-
-                let base64 = BASE64_STANDARD.encode(&encoded);
-
-                _serializer.serialize_str(&base64)
-            }
+    fn height(&self) -> u32 {
+        match self {
+            DecodedImageType::Bitmap { dimensions, .. } => dimensions.height(),
+            #[cfg(target_arch = "wasm32")]
+            DecodedImageType::JsImageBitmap(image_bitmap) => image_bitmap.height(),
         }
     }
 }
 
-impl<'de> Deserialize<'de> for DecodedImage {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let visitor = DecodedImageVisitor {};
-        deserializer.deserialize_str(visitor)
+#[cfg(feature = "image")]
+mod serialization {
+    use base64::{prelude::BASE64_STANDARD, Engine};
+    use image::ImageEncoder;
+
+    use super::*;
+
+    impl Serialize for DecodedImage {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            match &self.0 {
+                DecodedImageType::Bitmap { bytes, dimensions } => {
+                    use image::codecs::png::PngEncoder;
+                    use image::ColorType;
+
+                    let mut encoded = vec![];
+                    let encoder = PngEncoder::new(&mut encoded);
+                    if let Err(err) = encoder.write_image(
+                        &bytes,
+                        dimensions.width(),
+                        dimensions.height(),
+                        ColorType::Rgba8,
+                    ) {
+                        return Err(serde::ser::Error::custom(format!(
+                            "failed to encode image to PNG: {err}"
+                        )));
+                    }
+
+                    let base64 = BASE64_STANDARD.encode(&encoded);
+
+                    _serializer.serialize_str(&base64)
+                }
+                #[cfg(target_arch = "wasm32")]
+                _ => Err(serde::ser::Error::custom(
+                    "Serialization is only supported for raw bitmap image type",
+                )),
+            }
+        }
     }
-}
 
-struct DecodedImageVisitor {}
-impl Visitor<'_> for DecodedImageVisitor {
-    type Value = DecodedImage;
-
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-        formatter.write_str("base64 encoded image")
+    impl<'de> Deserialize<'de> for DecodedImage {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let visitor = DecodedImageVisitor {};
+            deserializer.deserialize_str(visitor)
+        }
     }
 
-    fn visit_str<E>(self, _v: &str) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        cfg_if::cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
-                panic!("should not be used in WASM");
-            } else {
-                let Ok(bytes) = BASE64_STANDARD.decode(_v) else {
-                    return Err(Error::custom("not a valid base64 string"));
-                };
+    struct DecodedImageVisitor {}
+    impl Visitor<'_> for DecodedImageVisitor {
+        type Value = DecodedImage;
 
-                DecodedImage::new(&bytes)
-                    .map_err(|err| Error::custom(format!("failed to decode image: {err}")))
+        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            formatter.write_str("base64 encoded image")
+        }
+
+        fn visit_str<E>(self, _v: &str) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            cfg_if::cfg_if! {
+                if #[cfg(target_arch = "wasm32")] {
+                    panic!("should not be used in WASM");
+                } else {
+                    let Ok(bytes) = BASE64_STANDARD.decode(_v) else {
+                        return Err(Error::custom("not a valid base64 string"));
+                    };
+
+                    DecodedImage::decode(&bytes)
+                        .map_err(|err| Error::custom(format!("failed to decode image: {err}")))
+                }
             }
         }
     }
@@ -151,13 +175,14 @@ impl Visitor<'_> for DecodedImageVisitor {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "image")]
     #[test]
     fn serialize_and_deserialize_decoded_image() {
         const IMAGE: &str = "\"iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=\"";
         let deserialized: DecodedImage =
             serde_json::from_str(IMAGE).expect("deserialization failed");
-        assert_ne!(deserialized.dimensions.0, 0);
-        assert_ne!(deserialized.dimensions.1, 0);
+        assert_ne!(deserialized.width(), 0);
+        assert_ne!(deserialized.height(), 0);
 
         let serialized = serde_json::to_string(&deserialized).expect("serialization failed");
         assert!(serialized.starts_with('\"'));

--- a/galileo/src/error.rs
+++ b/galileo/src/error.rs
@@ -20,7 +20,7 @@ pub enum GalileoError {
     #[error("item not found")]
     NotFound,
     /// Image decoding error.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "image")]
     #[error("image decode error")]
     ImageDecode,
     /// Generic error - details are inside.

--- a/galileo/src/galileo_map.rs
+++ b/galileo/src/galileo_map.rs
@@ -12,13 +12,10 @@ use galileo_types::cartesian::Size;
 use galileo_types::geo::impls::GeoPoint2d;
 use maybe_sync::{MaybeSend, MaybeSync};
 use std::sync::{Arc, RwLock};
-use wasm_bindgen::JsCast;
-use web_sys::HtmlCanvasElement;
 use winit::application::ApplicationHandler;
 use winit::dpi::PhysicalSize;
 use winit::event::WindowEvent;
 use winit::event_loop::EventLoop;
-use winit::platform::web::WindowAttributesExtWebSys;
 use winit::window::Window;
 
 #[cfg(target_arch = "wasm32")]
@@ -55,6 +52,10 @@ impl ApplicationHandler for GalileoMap {
 
         #[cfg(target_arch = "wasm32")]
         let window_attributes = {
+            use wasm_bindgen::JsCast;
+            use web_sys::HtmlCanvasElement;
+            use winit::platform::web::WindowAttributesExtWebSys;
+
             let document = web_sys::window()
                 .expect("failed to get window")
                 .document()
@@ -233,7 +234,7 @@ impl MapBuilder {
             .take()
             .unwrap_or_else(|| EventLoop::new().expect("Failed to create event loop."));
 
-        event_loop.set_control_flow(ControlFlow::Wait);
+        event_loop.set_control_flow(winit::event_loop::ControlFlow::Wait);
 
         log::info!("Trying to get window");
 
@@ -245,7 +246,7 @@ impl MapBuilder {
         for handler in self.event_handlers.drain(..) {
             event_processor.add_handler(handler);
         }
-        event_processor.add_handler(MapController::default());
+        event_processor.add_handler(crate::control::MapController::default());
 
         GalileoMap {
             window: None,

--- a/galileo/src/layer/data_provider/url_image_provider.rs
+++ b/galileo/src/layer/data_provider/url_image_provider.rs
@@ -97,7 +97,7 @@ where
     }
 
     fn decode(&self, bytes: Bytes, _context: ()) -> Result<DecodedImage, GalileoError> {
-        DecodedImage::new(&bytes)
+        DecodedImage::decode(&bytes)
     }
 }
 

--- a/galileo/src/layer/feature_layer/symbol/point.rs
+++ b/galileo/src/layer/feature_layer/symbol/point.rs
@@ -122,6 +122,6 @@ mod tests {
         .unwrap();
         assert_eq!(symbol.image.width(), 62);
         assert_eq!(symbol.image.height(), 99);
-        assert_eq!(symbol.image.bytes().len(), 62 * 99 * 4);
+        assert_eq!(symbol.image.size(), 62 * 99 * 4);
     }
 }

--- a/galileo/src/layer/feature_layer/symbol/point.rs
+++ b/galileo/src/layer/feature_layer/symbol/point.rs
@@ -67,6 +67,8 @@ impl ImagePointSymbol {
     /// Loads the image from the file system path.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn from_path(path: &str, offset: Vector2<f32>, scale: f32) -> Result<Self, GalileoError> {
+        use galileo_types::cartesian::Size;
+
         let image = image::io::Reader::open(path)?
             .decode()
             .map_err(|_| GalileoError::ImageDecode)?;
@@ -74,8 +76,7 @@ impl ImagePointSymbol {
         Ok(Self {
             image: Arc::new(DecodedImage::from_raw(
                 Vec::from(image.to_rgba8().deref()),
-                image.width(),
-                image.height(),
+                Size::new(image.width(), image.height()),
             )?),
             offset,
             scale,

--- a/galileo/src/layer/raster_tile_layer.rs
+++ b/galileo/src/layer/raster_tile_layer.rs
@@ -5,6 +5,7 @@ use crate::render::render_bundle::RenderBundle;
 use crate::render::{Canvas, ImagePaint, PackedBundle, PrimitiveId, RenderOptions};
 use crate::tile_scheme::{TileIndex, TileSchema};
 use crate::view::MapView;
+use galileo_types::cartesian::Size;
 use maybe_sync::{MaybeSend, MaybeSync, Mutex};
 use quick_cache::sync::Cache;
 use std::any::Any;
@@ -210,7 +211,7 @@ where
 
                     let owned = std::mem::replace(
                         &mut *decoded_image,
-                        DecodedImage::from_raw(vec![], 0, 0).expect("empty image is always ok"),
+                        DecodedImage::from_raw(vec![], Size::new(0, 0)).expect("empty image is always ok"),
                     );
 
                     let opacity = if self.fade_in_duration.is_zero() {

--- a/galileo/src/layer/raster_tile_layer.rs
+++ b/galileo/src/layer/raster_tile_layer.rs
@@ -211,7 +211,8 @@ where
 
                     let owned = std::mem::replace(
                         &mut *decoded_image,
-                        DecodedImage::from_raw(vec![], Size::new(0, 0)).expect("empty image is always ok"),
+                        DecodedImage::from_raw(vec![], Size::new(0, 0))
+                            .expect("empty image is always ok"),
                     );
 
                     let opacity = if self.fade_in_duration.is_zero() {

--- a/galileo/src/platform/native.rs
+++ b/galileo/src/platform/native.rs
@@ -29,7 +29,7 @@ impl PlatformService for NativePlatformService {
 
     async fn load_image_url(&self, url: &str) -> Result<DecodedImage, GalileoError> {
         let image_source = self.load_from_web(url).await?;
-        DecodedImage::new(&image_source)
+        DecodedImage::decode(&image_source)
     }
 
     async fn load_bytes_from_url(&self, url: &str) -> Result<Bytes, GalileoError> {

--- a/galileo/src/render/render_bundle/tessellating.rs
+++ b/galileo/src/render/render_bundle/tessellating.rs
@@ -135,7 +135,7 @@ impl TessellatingRenderBundle {
     ) -> PrimitiveId {
         let opacity = paint.opacity as f32 / 255.0;
 
-        self.buffer_size += image.bytes().len() + std::mem::size_of::<ImageVertex>() * 4;
+        self.buffer_size += image.size() + std::mem::size_of::<ImageVertex>() * 4;
 
         let index = self.add_image_to_store(Arc::new(image));
         let vertices = [
@@ -188,7 +188,7 @@ impl TessellatingRenderBundle {
     {
         let opacity = opacity as f32 / 255.0;
 
-        self.buffer_size += image.bytes().len() + size_of::<ImageVertex>() * 4;
+        self.buffer_size += image.size()+ size_of::<ImageVertex>() * 4;
 
         let position = [position.x().as_(), position.y().as_()];
         let offset_x = -offset[0] * width;
@@ -373,7 +373,7 @@ impl TessellatingRenderBundle {
                     ImageStoreInfo::Image(image) => {
                         self.vacant_image_store_ids.push(image_id);
 
-                        self.buffer_size -= image.bytes.len() + size_of::<ImageVertex>() * 4;
+                        self.buffer_size -= image.size() + size_of::<ImageVertex>() * 4;
                     }
                 }
             }

--- a/galileo/src/render/render_bundle/tessellating.rs
+++ b/galileo/src/render/render_bundle/tessellating.rs
@@ -188,7 +188,7 @@ impl TessellatingRenderBundle {
     {
         let opacity = opacity as f32 / 255.0;
 
-        self.buffer_size += image.size()+ size_of::<ImageVertex>() * 4;
+        self.buffer_size += image.size() + size_of::<ImageVertex>() * 4;
 
         let position = [position.x().as_(), position.y().as_()];
         let offset_x = -offset[0] * width;

--- a/galileo/src/render/wgpu/pipelines/image.rs
+++ b/galileo/src/render/wgpu/pipelines/image.rs
@@ -1,4 +1,4 @@
-use crate::decoded_image::DecodedImage;
+use crate::decoded_image::{DecodedImage, DecodedImageType};
 use crate::render::render_bundle::tessellating::ImageVertex;
 use crate::render::wgpu::pipelines;
 use crate::render::wgpu::pipelines::default_targets;
@@ -6,8 +6,8 @@ use crate::render::RenderOptions;
 use std::sync::Arc;
 use wgpu::util::{DeviceExt, TextureDataOrder};
 use wgpu::{
-    BindGroup, BindGroupLayout, Device, Queue, RenderPass, RenderPipeline,
-    RenderPipelineDescriptor, TextureFormat,
+    BindGroup, BindGroupLayout, Device, ExternalImageSource, ImageCopyExternalImage, Origin2d,
+    Queue, RenderPass, RenderPipeline, RenderPipelineDescriptor, TextureFormat,
 };
 
 const INDICES: &[u16] = &[1, 0, 2, 1, 2, 3];
@@ -98,21 +98,54 @@ impl ImagePipeline {
             depth_or_array_layers: 1,
         };
 
-        let texture = device.create_texture_with_data(
-            queue,
-            &wgpu::TextureDescriptor {
-                size: texture_size,
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: TextureFormat::Rgba8UnormSrgb,
-                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-                label: None,
-                view_formats: &[],
-            },
-            TextureDataOrder::default(),
-            image.bytes(),
-        );
+        let texture = match &image.0 {
+            DecodedImageType::Bitmap { bytes, .. } => device.create_texture_with_data(
+                queue,
+                &wgpu::TextureDescriptor {
+                    size: texture_size,
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: TextureFormat::Rgba8UnormSrgb,
+                    usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                    label: None,
+                    view_formats: &[],
+                },
+                TextureDataOrder::default(),
+                bytes,
+            ),
+            DecodedImageType::JsImageBitmap(image) => {
+                let texture = device.create_texture(&wgpu::TextureDescriptor {
+                    size: texture_size,
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: TextureFormat::Rgba8UnormSrgb,
+                    usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    label: None,
+                    view_formats: &[],
+                });
+                let texture_size = wgpu::Extent3d {
+                    width: image.width(),
+                    height: image.height(),
+                    depth_or_array_layers: 1,
+                };
+                let image = ImageCopyExternalImage {
+                    source: ExternalImageSource::ImageBitmap(image.clone()),
+                    origin: Origin2d::ZERO,
+                    flip_y: false,
+                };
+                queue.copy_external_image_to_texture(
+                    &image,
+                    texture
+                        .as_image_copy()
+                        .to_tagged(wgpu::PredefinedColorSpace::Srgb, false),
+                    texture_size,
+                );
+
+                texture
+            }
+        };
 
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/galileo/src/render/wgpu/pipelines/image.rs
+++ b/galileo/src/render/wgpu/pipelines/image.rs
@@ -6,8 +6,8 @@ use crate::render::RenderOptions;
 use std::sync::Arc;
 use wgpu::util::{DeviceExt, TextureDataOrder};
 use wgpu::{
-    BindGroup, BindGroupLayout, Device, ExternalImageSource, ImageCopyExternalImage, Origin2d,
-    Queue, RenderPass, RenderPipeline, RenderPipelineDescriptor, TextureFormat,
+    BindGroup, BindGroupLayout, Device, Queue, RenderPass, RenderPipeline,
+    RenderPipelineDescriptor, TextureFormat,
 };
 
 const INDICES: &[u16] = &[1, 0, 2, 1, 2, 3];
@@ -114,14 +114,19 @@ impl ImagePipeline {
                 TextureDataOrder::default(),
                 bytes,
             ),
+            #[cfg(target_arch = "wasm32")]
             DecodedImageType::JsImageBitmap(image) => {
+                use wgpu::{ExternalImageSource, ImageCopyExternalImage, Origin2d};
+
                 let texture = device.create_texture(&wgpu::TextureDescriptor {
                     size: texture_size,
                     mip_level_count: 1,
                     sample_count: 1,
                     dimension: wgpu::TextureDimension::D2,
                     format: TextureFormat::Rgba8UnormSrgb,
-                    usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST | wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    usage: wgpu::TextureUsages::TEXTURE_BINDING
+                        | wgpu::TextureUsages::COPY_DST
+                        | wgpu::TextureUsages::RENDER_ATTACHMENT,
                     label: None,
                     view_formats: &[],
                 });

--- a/wasm_examples/raster_tiles/README.md
+++ b/wasm_examples/raster_tiles/README.md
@@ -7,10 +7,13 @@ To run this example, first build Galileo as wasm package:
 wasm-pack build --release galileo
 ```
 
+Make sure that you use `wasm-opt` of version heigher than 119.
+
 After the package is created, use `npm` and `webpack` to build and run the example:
 
 ```
 npm install
-npm build
-npm run
+npm run build
+npm run start
 ```
+

--- a/wasm_examples/raster_tiles/package.json
+++ b/wasm_examples/raster_tiles/package.json
@@ -12,8 +12,8 @@
   },
   "devDependencies": {
     "copy-webpack-plugin": "^5.0.0",
-    "webpack": "^4.29.3",
-    "webpack-cli": "^3.1.0",
-    "webpack-dev-server": "^3.1.5"
+    "webpack": "^5.97",
+    "webpack-cli": "^5.1.0",
+    "webpack-dev-server": "^5.1.0"
   }
 }

--- a/wasm_examples/raster_tiles/webpack.config.js
+++ b/wasm_examples/raster_tiles/webpack.config.js
@@ -8,7 +8,17 @@ module.exports = {
     filename: "bootstrap.js",
   },
   mode: "development",
+  experiments: {
+    asyncWebAssembly: true,
+  },
   plugins: [
     new CopyWebpackPlugin(['index.html'])
   ],
+  devServer: {
+    client: {
+      overlay: {
+        runtimeErrors: false
+      },
+    },
+  },
 };


### PR DESCRIPTION
There are a few issues with web examples currently and this PR fixes some of them:
1. After we updated winit, the way window is initialized is changed considerably, but those changes were not reflected for the wasm32 target. This PR fixes that.
2. For some reason decoding of the tile images using canvas image data stopped working. Luckily, we don't need to use this approach anymore since all modern browsers allow creating textures from directly from images using `ImageBitmap`. So this PR replaces the old approach for decoding the images with the new one. This lead to a considerable rewrite of the `DecodedImage` structure, but it should not affect any of the API code.