### PR TITLE
Fix warning by wasm_bingen when compiling for wasm target

### DIFF
--- a/galileo/Cargo.toml
+++ b/galileo/Cargo.toml
@@ -120,3 +120,7 @@ assert_matches = "1.5"
 [[example]]
 name = "render_to_file"
 required-features = ["geojson"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+


### PR DESCRIPTION
When using nightly version of the compiler, building for wasm32 target emits a bunch of warnings rooted in the `wasm_bindgen` macro:

```
warning: unexpected `cfg` condition name: `wasm_bindgen_unstable_test_coverage`
```

This commit prevents this noise by following the suggestion from the related `wasm_bindgen` [issue](https://github.com/rustwasm/wasm-bindgen/issues/4283).