### PR TITLE
Make vector tile layer init synchronous

### DIFF
--- a/galileo/examples/vector_tiles.rs
+++ b/galileo/examples/vector_tiles.rs
@@ -55,20 +55,18 @@ async fn main() {
 }
 
 pub async fn run(builder: MapBuilder, style: VectorTileStyle, api_key: String) {
-    let layer =
-        Arc::new(RwLock::new(
-            MapBuilder::create_vector_tile_layer(
-                move |&index: &TileIndex| {
-                    format!(
-                    "https://api.maptiler.com/tiles/v3-openmaptiles/{z}/{x}/{y}.pbf?key={api_key}",
-                    z = index.z, x = index.x, y = index.y
-                )
-                },
-                tile_scheme(),
-                style,
+    let layer = Arc::new(RwLock::new(MapBuilder::create_vector_tile_layer(
+        move |&index: &TileIndex| {
+            format!(
+                "https://api.maptiler.com/tiles/v3-openmaptiles/{z}/{x}/{y}.pbf?key={api_key}",
+                z = index.z,
+                x = index.x,
+                y = index.y
             )
-            .await,
-        ));
+        },
+        tile_scheme(),
+        style,
+    )));
 
     builder
         .with_layer(layer.clone())

--- a/galileo/examples/vector_tiles_labels.rs
+++ b/galileo/examples/vector_tiles_labels.rs
@@ -64,8 +64,7 @@ pub async fn run(builder: MapBuilder, style: VectorTileStyle, api_key: String) {
         tile_schema(),
     );
 
-    let graphics_layer =
-        VectorTileLayer::from_url(tile_provider.clone(), style, tile_schema()).await;
+    let graphics_layer = VectorTileLayer::from_url(tile_provider.clone(), style, tile_schema());
 
     let style = VectorTileStyle {
         rules: vec![],
@@ -85,7 +84,7 @@ pub async fn run(builder: MapBuilder, style: VectorTileStyle, api_key: String) {
         },
         background: Default::default(),
     };
-    let label_layer = VectorTileLayer::from_url(tile_provider, style, tile_schema()).await;
+    let label_layer = VectorTileLayer::from_url(tile_provider, style, tile_schema());
 
     builder
         .with_layer(graphics_layer)

--- a/galileo/src/galileo_map.rs
+++ b/galileo/src/galileo_map.rs
@@ -296,15 +296,17 @@ impl MapBuilder {
     }
 
     /// Add a vector tile layer with the given parameters.
-    pub async fn with_vector_tiles(
+    pub fn with_vector_tiles(
         mut self,
         tile_source: impl UrlSource<TileIndex> + 'static,
         tile_scheme: TileSchema,
         style: VectorTileStyle,
     ) -> Self {
-        self.layers.push(Box::new(
-            Self::create_vector_tile_layer(tile_source, tile_scheme, style).await,
-        ));
+        self.layers.push(Box::new(Self::create_vector_tile_layer(
+            tile_source,
+            tile_scheme,
+            style,
+        )));
         self
     }
 

--- a/galileo/src/layer/vector_tile_layer/mod.rs
+++ b/galileo/src/layer/vector_tile_layer/mod.rs
@@ -85,12 +85,12 @@ where
     }
 
     /// Creates a new layer with the given url source.
-    pub async fn from_url(
+    pub fn from_url(
         mut tile_provider: VectorTileProvider<Loader, Processor>,
         style: VectorTileStyle,
         tile_scheme: TileSchema,
     ) -> Self {
-        let style_id = tile_provider.add_style(style).await;
+        let style_id = tile_provider.add_style(style);
         Self {
             tile_provider,
             tile_scheme,
@@ -141,8 +141,8 @@ where
     }
 
     /// Change style of the layer and redraw it.
-    pub async fn update_style(&mut self, style: VectorTileStyle) {
-        let new_style_id = self.tile_provider.add_style(style).await;
+    pub fn update_style(&mut self, style: VectorTileStyle) {
+        let new_style_id = self.tile_provider.add_style(style);
         self.style_id = new_style_id;
     }
 

--- a/galileo/src/layer/vector_tile_layer/tile_provider/mod.rs
+++ b/galileo/src/layer/vector_tile_layer/tile_provider/mod.rs
@@ -88,16 +88,16 @@ where
     }
 
     /// Register a new style in the provider.
-    pub async fn add_style(&mut self, style: VectorTileStyle) -> VtStyleId {
+    pub fn add_style(&mut self, style: VectorTileStyle) -> VtStyleId {
         let id = VtStyleId::next_id();
-        self.processor.add_style(id, style).await;
+        self.processor.add_style(id, style);
 
         id
     }
 
     /// Removes the style from the list of registerred styles.
-    pub async fn drop_style(&mut self, style_id: VtStyleId) {
-        self.processor.drop_style(style_id).await;
+    pub fn drop_style(&mut self, style_id: VtStyleId) {
+        self.processor.drop_style(style_id);
     }
 
     /// Load and pre-render the tile with given index using given style.

--- a/galileo/src/layer/vector_tile_layer/tile_provider/processor.rs
+++ b/galileo/src/layer/vector_tile_layer/tile_provider/processor.rs
@@ -31,9 +31,9 @@ pub trait VectorTileProcessor {
     /// Returns a style with the given id.
     fn get_style(&self, style_id: VtStyleId) -> Option<Arc<VectorTileStyle>>;
     /// Registers a vector tile style.
-    async fn add_style(&self, style_id: VtStyleId, style: VectorTileStyle);
+    fn add_style(&self, style_id: VtStyleId, style: VectorTileStyle);
     /// Removes the style from the list.
-    async fn drop_style(&self, style_id: VtStyleId);
+    fn drop_style(&self, style_id: VtStyleId);
     /// Convert the tile into render bundle using the given style.
     ///
     /// The style with the given id must first be registerred in the processor using [`add_style`]

--- a/galileo/src/platform/native/map_builder.rs
+++ b/galileo/src/platform/native/map_builder.rs
@@ -59,13 +59,13 @@ impl MapBuilder {
     }
 
     /// Create a new vector tile layer.
-    pub async fn create_vector_tile_layer(
+    pub fn create_vector_tile_layer(
         tile_source: impl UrlSource<TileIndex> + 'static,
         tile_schema: TileSchema,
         style: VectorTileStyle,
     ) -> VectorTileLayer<WebVtLoader<FileCacheController>, ThreadVtProcessor> {
         let tile_provider = Self::create_vector_tile_provider(tile_source, tile_schema.clone());
-        VectorTileLayer::from_url(tile_provider, style, tile_schema).await
+        VectorTileLayer::from_url(tile_provider, style, tile_schema)
     }
 
     /// Returns a vector tile provider.

--- a/galileo/src/platform/native/vt_processor.rs
+++ b/galileo/src/platform/native/vt_processor.rs
@@ -49,14 +49,14 @@ impl VectorTileProcessor for ThreadVtProcessor {
             .cloned()
     }
 
-    async fn add_style(&self, style_id: VtStyleId, style: VectorTileStyle) {
+    fn add_style(&self, style_id: VtStyleId, style: VectorTileStyle) {
         self.styles
             .write()
             .expect("lock is poisoned")
             .insert(style_id, Arc::new(style));
     }
 
-    async fn drop_style(&self, style_id: VtStyleId) {
+    fn drop_style(&self, style_id: VtStyleId) {
         self.styles
             .write()
             .expect("lock is poisoned")

--- a/galileo/src/platform/web/map_builder.rs
+++ b/galileo/src/platform/web/map_builder.rs
@@ -32,13 +32,13 @@ impl MapBuilder {
     }
 
     /// Create a new vector tile layer.
-    pub async fn create_vector_tile_layer(
+    pub fn create_vector_tile_layer(
         tile_source: impl UrlSource<TileIndex> + 'static,
         tile_schema: TileSchema,
         style: VectorTileStyle,
     ) -> VectorTileLayer<WebVtLoader<DummyCacheController>, WebWorkerVtProcessor> {
         let tile_provider = Self::create_vector_tile_provider(tile_source, tile_schema.clone());
-        VectorTileLayer::from_url(tile_provider, style, tile_schema).await
+        VectorTileLayer::from_url(tile_provider, style, tile_schema)
     }
 
     /// Create a new vector tile provider.

--- a/galileo/src/platform/web/vt_processor.rs
+++ b/galileo/src/platform/web/vt_processor.rs
@@ -43,11 +43,11 @@ impl VectorTileProcessor for WebWorkerVtProcessor {
         self.styles.borrow().get(&style_id).cloned()
     }
 
-    async fn add_style(&self, style_id: VtStyleId, style: VectorTileStyle) {
+    fn add_style(&self, style_id: VtStyleId, style: VectorTileStyle) {
         self.styles.borrow_mut().insert(style_id, Arc::new(style));
     }
 
-    async fn drop_style(&self, style_id: VtStyleId) {
+    fn drop_style(&self, style_id: VtStyleId) {
         self.styles.borrow_mut().remove(&style_id);
     }
 


### PR DESCRIPTION
There are quite a few issues with having the layer initialization method asynchronous. This was originally done to allow sending vector tile styles to the web workers when we initialize the layer, but I think we must find a better approach to do that.

So this commit changes the initialization API to sync. No changes to the tile processor are needed as sending the styles to the workers is not yet implemented.