### PR TITLE
Improve vector tile styles

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,9 @@ keywords = ["gis", "map", "rendering"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Maximkaaa/galileo"
 version = "0.1.1"
+
+[workspace.lints]
+rust.missing_docs = "warn"
+rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+clippy.unwrap_used = "warn"
+

--- a/galileo-types/Cargo.toml
+++ b/galileo-types/Cargo.toml
@@ -21,3 +21,7 @@ nalgebra = "0.32"
 num-traits = "0.2.17"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+
+[lints]
+workspace = true
+

--- a/galileo-types/src/lib.rs
+++ b/galileo-types/src/lib.rs
@@ -80,9 +80,6 @@
 //! * `geo-types` - enabled by `geo-types` feature
 //! * `geojson` - enabled by `geojson` feature
 
-#![warn(clippy::unwrap_used)]
-#![warn(missing_docs)]
-
 pub mod cartesian;
 pub mod contour;
 mod disambig;

--- a/galileo/Cargo.toml
+++ b/galileo/Cargo.toml
@@ -119,6 +119,6 @@ winit = { version = "0.30", features = ["android-native-activity"] }
 name = "render_to_file"
 required-features = ["geojson"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+[lints]
+workspace = true
 

--- a/galileo/examples/data/vt_style.json
+++ b/galileo/examples/data/vt_style.json
@@ -2,7 +2,6 @@
   "rules": [
     {
       "layer_name": "park",
-      "symbol": {},
       "properties": {
         "class": "protected_area"
       }
@@ -179,7 +178,6 @@
     },
     {
       "layer_name": "park",
-      "symbol": {},
       "properties": {
         "class": "национальный_парк"
       }
@@ -206,12 +204,8 @@
       "fill_color": "#00000010"
     },
     "point": {
-      "shape": {
-        "type": "Circle",
-        "radius": 1.2,
-        "fill": {"center_color": "#ff0000ff", "side_color": "#ff0000ff"}
-      },
-      "offset": [0.0, 0.0]
+      "size": 2.4,
+      "color": "#ff0000ff"
     }
   },
   "background": "#fff3e4"

--- a/galileo/examples/vector_tiles.rs
+++ b/galileo/examples/vector_tiles.rs
@@ -31,7 +31,7 @@ use tokio::sync::OnceCell;
 #[cfg(not(target_arch = "wasm32"))]
 fn get_layer_style() -> Option<VectorTileStyle> {
     const STYLE: &str = "galileo/examples/data/vt_style.json";
-    serde_json::from_reader(std::fs::File::open(STYLE).ok()?).ok()
+    Some(serde_json::from_reader(std::fs::File::open(STYLE).unwrap()).unwrap())
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/galileo/examples/vector_tiles_labels.rs
+++ b/galileo/examples/vector_tiles_labels.rs
@@ -1,5 +1,7 @@
 use bytes::Bytes;
-use galileo::layer::vector_tile_layer::style::{VectorTileStyle, VectorTileSymbol};
+use galileo::layer::vector_tile_layer::style::{
+    VectorTileDefaultSymbol, VectorTileLabelSymbol, VectorTileStyle, VectorTileSymbol,
+};
 #[cfg(target_arch = "wasm32")]
 use galileo::layer::vector_tile_layer::tile_provider::WebWorkerVectorTileProvider;
 use galileo::layer::vector_tile_layer::VectorTileLayer;
@@ -68,19 +70,18 @@ pub async fn run(builder: MapBuilder, style: VectorTileStyle, api_key: String) {
 
     let style = VectorTileStyle {
         rules: vec![],
-        default_symbol: VectorTileSymbol {
-            point: Some(PointPaint::label_owed(
-                "{name_en}".into(),
-                TextStyle {
+        default_symbol: VectorTileDefaultSymbol {
+            label: Some(VectorTileLabelSymbol {
+                pattern: "{name_en}".into(),
+                text_style: TextStyle {
                     font_name: "Noto Sans".to_string(),
                     font_size: 12.0,
                     font_color: Color::BLACK,
                     horizontal_alignment: Default::default(),
                     vertical_alignment: Default::default(),
                 },
-            )),
-            line: None,
-            polygon: None,
+            }),
+            ..Default::default()
         },
         background: Default::default(),
     };

--- a/galileo/src/lib.rs
+++ b/galileo/src/lib.rs
@@ -65,9 +65,6 @@
 //!   some intermediate representation, more convenient to deal with, and some
 //! * [`controls`](control) that actually change state of the map or layers based on the user input.
 
-#![warn(clippy::unwrap_used)]
-#![warn(missing_docs)]
-
 pub(crate) mod async_runtime;
 mod color;
 pub mod control;

--- a/galileo/src/render/point_paint.rs
+++ b/galileo/src/render/point_paint.rs
@@ -105,7 +105,7 @@ impl<'a> PointPaint<'a> {
     }
 
     /// Creates a paint that draws given text label with the specified style.
-    pub fn label_owed(text: String, style: TextStyle) -> Self {
+    pub fn label_owned(text: String, style: TextStyle) -> Self {
         Self {
             offset: Vector2::new(0.0, 0.0),
             shape: PointShape::Label {


### PR DESCRIPTION
This PR changes `VectorTileSymbol` for struct to enum, and switches to using `VectorTilePointSymbol` instead of directly using `PointPaint` to style points.