### PR TITLE
Fix vt performance on web

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ exclude = [
     "wasm_examples/with_egui",
 ]
 
+[profile.release]
+debug = true
+
 [workspace.package]
 authors = ["Maxim Gritsenko <maxim@gritsenko.biz>"]
 categories = ["science::geo"]
@@ -40,7 +43,8 @@ approx = "0.5"
 assert_matches = "1.5"
 async-trait = "0.1"
 base64 = "0.21"
-bincode = "1.3"
+bincode = "2.0.0-rc.3"
+bitcode = "0.6"
 bytemuck = "1.14"
 bytes = "1.4"
 cfg-if = "1"

--- a/galileo/Cargo.toml
+++ b/galileo/Cargo.toml
@@ -53,7 +53,7 @@ winit = { workspace = true, default-features = true, features = ["rwh_06"], opti
 anyhow = { workspace = true }
 approx = { workspace = true }
 assert_matches = { workspace = true }
-bincode = { workspace = true }
+bincode = { workspace = true, features = ["serde"] }
 csv = { workspace = true }
 eframe = { workspace = true }
 egui = { workspace = true }
@@ -88,7 +88,7 @@ wasm-bindgen-derive = { workspace = true }
 js-sys = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_bytes = { workspace = true }
-bincode = { workspace = true }
+bincode = { workspace = true, features = ["serde"] }
 serde-wasm-bindgen = { workspace = true }
 maybe-sync = { workspace = true, features = [] }
 getrandom = { workspace = true, features = ["js"] }

--- a/galileo/examples/feature_layers.rs
+++ b/galileo/examples/feature_layers.rs
@@ -49,7 +49,12 @@ fn create_map(countries_layer: impl Layer + 'static) -> Map {
 }
 
 fn load_countries() -> Vec<Country> {
-    bincode::deserialize(include_bytes!("data/countries.data")).expect("invalid countries data")
+    bincode::serde::decode_from_slice(
+        include_bytes!("data/countries.data"),
+        bincode::config::legacy(),
+    )
+    .expect("invalid countries data")
+    .0
 }
 
 fn load_cities() -> Vec<City> {

--- a/galileo/examples/lambert.rs
+++ b/galileo/examples/lambert.rs
@@ -40,8 +40,12 @@ pub(crate) fn run() {
 }
 
 fn load_countries() -> Vec<Country> {
-    bincode::deserialize(include_bytes!("data/countries_simpl.data"))
-        .expect("invalid countries data")
+    bincode::serde::decode_from_slice(
+        include_bytes!("data/countries_simpl.data"),
+        bincode::config::legacy(),
+    )
+    .expect("invalid countries data")
+    .0
 }
 
 fn create_mouse_handler(

--- a/galileo/src/layer/vector_tile_layer/style.rs
+++ b/galileo/src/layer/vector_tile_layer/style.rs
@@ -69,7 +69,7 @@ pub struct StyleRule {
     #[serde(default)]
     pub properties: HashMap<String, String>,
     /// Symbol to draw a feature with.
-    #[serde(default, skip_serializing_if = "VectorTileSymbol::is_none")]
+    #[serde(default)]
     pub symbol: VectorTileSymbol,
 }
 
@@ -101,10 +101,6 @@ impl Default for VectorTileSymbol {
 }
 
 impl VectorTileSymbol {
-    pub(crate) fn is_none(&self) -> bool {
-        matches!(self, Self::None)
-    }
-
     pub(crate) fn line(&self) -> Option<&VectorTileLineSymbol> {
         match self {
             Self::Line(symbol) => Some(symbol),
@@ -210,5 +206,18 @@ mod tests {
         let value = serde_json::to_value(&symbol).unwrap();
         assert!(value.as_object().unwrap().get("point").is_some());
         assert!(value.as_object().unwrap().get("polygon").is_none());
+    }
+
+    #[test]
+    fn serialize_with_bincode() {
+        let rule = StyleRule {
+            layer_name: None,
+            properties: HashMap::new(),
+            symbol: VectorTileSymbol::None,
+        };
+
+        let serialized = bincode::serde::encode_to_vec(&rule, bincode::config::standard()).unwrap();
+        let _: (StyleRule, _) =
+            bincode::serde::decode_from_slice(&serialized, bincode::config::standard()).unwrap();
     }
 }

--- a/justfile
+++ b/justfile
@@ -6,4 +6,3 @@ default:
 web_example NAME:
   wasm-pack build web-example --release --target no-modules --target-dir target --features {{NAME}}
   cd web-example && python3 -m http.server
-  # cd web-example && trunk serve --features {{NAME}} --release


### PR DESCRIPTION
Instead of directly convert web worker requests and responses to `JsValue` we serialize them with bincode instead and transfer to and from web workers using `ArrayBuffer`s by `serde_bytes`. This improves performance of the transfer back and forth by a factor of 10.

Fixes #92 