### PR TITLE
Upgrade wgpu to 24 and egui to 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ version = "0.1.1"
 
 [workspace.lints]
 rust.missing_docs = "warn"
-rust.unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+rust.unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(wasm_bindgen_unstable_test_coverage)',
+] }
 clippy.unwrap_used = "warn"
 
 [workspace.dependencies]
@@ -51,9 +53,9 @@ cfg-if = "1"
 console_log = "1"
 console_error_panic_hook = "0.1"
 csv = "1.3"
-egui = "0.30"
-egui-wgpu = "0.30"
-eframe = { version = "0.30", default-features = false }
+egui = "0.31"
+egui-wgpu = "0.31"
+eframe = { version = "0.31", default-features = false }
 env_logger = "0.11"
 futures = "0.3"
 futures-intrusive = "0.5"
@@ -99,5 +101,5 @@ wasm-bindgen-derive = "0.2"
 wasm-bindgen-futures = "0.4"
 web-time = "1"
 web-sys = "0.3"
-wgpu = { version = "23", default-features = false }
+wgpu = { version = "24", default-features = false }
 winit = { version = "0.30", default-features = false }


### PR DESCRIPTION
I'm playing with embedding into an Iced build, where Iced's shader module only provides &Device and &Queue references. This update provides Device::clone() and Queue::clone() for shallow copies, replacing the Arc wrappers, making this integration signature compatible during renderer setup.