### PR TITLE
Clippy fixes

### DIFF
--- a/galileo-types/src/lib.rs
+++ b/galileo-types/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //! A subset of OGC geometry types are supported at the moment:
 //! * [`GeoPoint`](geo::GeoPoint), [`CartesianPoint2d`](cartesian::CartesianPoint2d), [`CartesianPoint3d`](cartesian::CartesianPoint2d)
-//!    (correspond to OGC *Point* geometry)
+//!   (correspond to OGC *Point* geometry)
 //! * [`MultiPoint`]
 //! * [`Contour`] (corresponds to OGC *LineString* geometry with slight difference, check the trait's documentation)
 //! * [`MultiContour`] (corresponds to OGC *MultiLineString* geometry)

--- a/galileo/src/layer/raster_tile_layer/provider.rs
+++ b/galileo/src/layer/raster_tile_layer/provider.rs
@@ -92,7 +92,7 @@ impl RestTileProvider {
 
         if let Some(cache) = &self.cache {
             if let Err(error) = cache.insert(&url, &data) {
-                log::warn!("Failed to write persistent cache entry: {:?}", error);
+                log::warn!("Failed to write persistent cache entry: {error:?}");
             }
         }
 

--- a/galileo/src/layer/vector_tile_layer/tile_provider/loader.rs
+++ b/galileo/src/layer/vector_tile_layer/tile_provider/loader.rs
@@ -70,7 +70,7 @@ impl WebVtLoader {
 
         if let Some(cache) = &self.cache {
             if let Err(error) = cache.insert(url, &bytes) {
-                log::warn!("Failed to write persistent cache entry: {:?}", error);
+                log::warn!("Failed to write persistent cache entry: {error:?}");
             }
         }
 

--- a/galileo/src/layer/vector_tile_layer/tile_provider/vt_processor.rs
+++ b/galileo/src/layer/vector_tile_layer/tile_provider/vt_processor.rs
@@ -176,7 +176,7 @@ impl VtProcessor {
                 .map(|v| v.to_string())
                 .unwrap_or_default();
 
-            text = text.replace(&format!("{{{}}}", prop_name), &prop);
+            text = text.replace(&format!("{{{prop_name}}}"), &prop);
         }
         Some(PointPaint::label_owned(
             text,

--- a/galileo/src/lib.rs
+++ b/galileo/src/lib.rs
@@ -20,12 +20,15 @@
 //! **src/main.rs:**
 //! ```rust
 //! use galileo::layer::raster_tile_layer::RasterTileLayerBuilder;
-//! use galileo::{Map, MapBuilder, TileSchema };
+//! use galileo::{Map, MapBuilder};
 //! use galileo::layer::FeatureLayer;
 //! use galileo::symbol::CirclePointSymbol;
 //! use galileo::galileo_types::latlon;
 //! use galileo_types::geo::Crs;
 //! use galileo::Color;
+//! 
+//! mod app;
+//! use app::MapApp;
 //! 
 //! fn main() {
 //!     run()
@@ -33,7 +36,7 @@
 //! 
 //! // Creates the window and starts the egui event loop.
 //! pub(crate) fn run() {
-//!     galileo_egui::init(create_map(), [])
+//!     galileo_egui::init_with_app(Box::new(|cc| Ok(Box::new(MapApp::new(create_map(),cc,[])))))
 //!         .expect("Couldn't create window");
 //! }
 //! 
@@ -41,10 +44,9 @@
 //! fn create_map()->Map {
 //!     MapBuilder::default()
 //!         // Set the position of the center of the map view
-//!         .with_position(latlon!(37.566, 126.9784))
-//!         // Set the size of the smallest visible feature (zoom level) for the view to start
-//!         // with.
-//!         .with_resolution(TileSchema::web(18).lod_resolution(8).unwrap())
+//!         .with_latlon(37.566, 126.9784)
+//!         // Set the size of the smallest visible feature (zoom level) for the view to start with.
+//!         .with_z_level(8)
 //!         // Add the Open Street Maps raster tile server as a layer
 //!         .with_layer(RasterTileLayerBuilder::new_osm().build().unwrap())
 //!         // Add a blue dot at the coordinates specified
@@ -53,8 +55,7 @@
 //!             vec![latlon!(37.566, 126.9784)], 
 //!             // a blue circle with fixed size of 5.0 pixels
 //!             CirclePointSymbol::new(Color::BLUE, 5.0), 
-//!             // WGS84 is the coordinate reference system that's based on latitude/longitude
-//!             // pairs.
+//!             // WGS84 is the coordinate reference system that's based on latitude/longitude pairs.
 //!             Crs::WGS84, 
 //!         ))
 //!         .build()

--- a/galileo/src/lib.rs
+++ b/galileo/src/lib.rs
@@ -4,21 +4,20 @@
 //! # Quick start
 //!
 //! **Cargo.toml:**
-//!```toml
-//! 
+//! ```toml
 //! [package]
 //! name = "map-view"
 //! version = "0.1.0"
 //! edition = "2024"
-//! 
+//!
 //! [dependencies]
 //! galileo = {git = "https://github.com/maximkaaa/galileo"}
 //! galileo-types = {git = "https://github.com/maximkaaa/galileo"}
 //! galileo-egui = {git = "https://github.com/maximkaaa/galileo"}
-//!```
+//! ```
 //!
 //! **src/main.rs:**
-//! ```rust
+//! ```no_run
 //! use galileo::layer::raster_tile_layer::RasterTileLayerBuilder;
 //! use galileo::{Map, MapBuilder};
 //! use galileo::layer::FeatureLayer;
@@ -26,20 +25,17 @@
 //! use galileo::galileo_types::latlon;
 //! use galileo_types::geo::Crs;
 //! use galileo::Color;
-//! 
-//! mod app;
-//! use app::MapApp;
-//! 
+//!
 //! fn main() {
 //!     run()
 //! }
-//! 
+//!
 //! // Creates the window and starts the egui event loop.
 //! pub(crate) fn run() {
-//!     galileo_egui::init_with_app(Box::new(|cc| Ok(Box::new(MapApp::new(create_map(),cc,[])))))
+//!     galileo_egui::init(create_map(), [])
 //!         .expect("Couldn't create window");
 //! }
-//! 
+//!
 //! // build a map showing the Open Street Map raster data for Seoul, South Korea
 //! fn create_map()->Map {
 //!     MapBuilder::default()
@@ -52,15 +48,15 @@
 //!         // Add a blue dot at the coordinates specified
 //!         .with_layer(FeatureLayer::new(
 //!             // the position of the marker we're going to add, in the WGS84 CRS
-//!             vec![latlon!(37.566, 126.9784)], 
+//!             vec![latlon!(37.566, 126.9784)],
 //!             // a blue circle with fixed size of 5.0 pixels
-//!             CirclePointSymbol::new(Color::BLUE, 5.0), 
+//!             CirclePointSymbol::new(Color::BLUE, 5.0),
 //!             // WGS84 is the coordinate reference system that's based on latitude/longitude pairs.
-//!             Crs::WGS84, 
+//!             Crs::WGS84,
 //!         ))
 //!         .build()
 //! }
-//!```
+//! ```
 //!
 //! # Main components of Galileo
 //!

--- a/galileo/src/lib.rs
+++ b/galileo/src/lib.rs
@@ -3,7 +3,63 @@
 //!
 //! # Quick start
 //!
-//! TODO
+//! **Cargo.toml:**
+//!```toml
+//! 
+//! [package]
+//! name = "map-view"
+//! version = "0.1.0"
+//! edition = "2024"
+//! 
+//! [dependencies]
+//! galileo = {git = "https://github.com/maximkaaa/galileo"}
+//! galileo-types = {git = "https://github.com/maximkaaa/galileo"}
+//! galileo-egui = {git = "https://github.com/maximkaaa/galileo"}
+//!```
+//!
+//! **src/main.rs:**
+//! ```rust
+//! use galileo::layer::raster_tile_layer::RasterTileLayerBuilder;
+//! use galileo::{Map, MapBuilder, TileSchema };
+//! use galileo::layer::FeatureLayer;
+//! use galileo::symbol::CirclePointSymbol;
+//! use galileo::galileo_types::latlon;
+//! use galileo_types::geo::Crs;
+//! use galileo::Color;
+//! 
+//! fn main() {
+//!     run()
+//! }
+//! 
+//! // Creates the window and starts the egui event loop.
+//! pub(crate) fn run() {
+//!     galileo_egui::init(create_map(), [])
+//!         .expect("Couldn't create window");
+//! }
+//! 
+//! // build a map showing the Open Street Map raster data for Seoul, South Korea
+//! fn create_map()->Map {
+//!     MapBuilder::default()
+//!         // Set the position of the center of the map view
+//!         .with_position(latlon!(37.566, 126.9784))
+//!         // Set the size of the smallest visible feature (zoom level) for the view to start
+//!         // with.
+//!         .with_resolution(TileSchema::web(18).lod_resolution(8).unwrap())
+//!         // Add the Open Street Maps raster tile server as a layer
+//!         .with_layer(RasterTileLayerBuilder::new_osm().build().unwrap())
+//!         // Add a blue dot at the coordinates specified
+//!         .with_layer(FeatureLayer::new(
+//!             // the position of the marker we're going to add, in the WGS84 CRS
+//!             vec![latlon!(37.566, 126.9784)], 
+//!             // a blue circle with fixed size of 5.0 pixels
+//!             CirclePointSymbol::new(Color::BLUE, 5.0), 
+//!             // WGS84 is the coordinate reference system that's based on latitude/longitude
+//!             // pairs.
+//!             Crs::WGS84, 
+//!         ))
+//!         .build()
+//! }
+//!```
 //!
 //! # Main components of Galileo
 //!

--- a/galileo/src/render/point_paint.rs
+++ b/galileo/src/render/point_paint.rs
@@ -80,7 +80,7 @@ impl<'a> PointPaint<'a> {
     }
 
     /// Creates a paint that draws given text label with the specified style.
-    pub fn label(text: &'a String, style: &'a TextStyle) -> Self {
+    pub fn label(text: &'a str, style: &'a TextStyle) -> Self {
         Self {
             offset: Vector2::default(),
             shape: PointShape::Label {

--- a/galileo/src/render/point_paint.rs
+++ b/galileo/src/render/point_paint.rs
@@ -157,7 +157,7 @@ pub(crate) enum PointShape<'a> {
         shape: Cow<'a, ClosedContour<Point2<f32>>>,
     },
     Label {
-        text: Cow<'a, String>,
+        text: Cow<'a, str>,
         style: Cow<'a, TextStyle>,
     },
 }


### PR DESCRIPTION
Clippy was complaining about having format strings with the variables as arguments after the string, and about using an owned String instead of str in a Cow. I just updated those places to get rid of the clippy warnings.