### PR TITLE
Use Vec2::floor on available_size to prevent redraw loop in EguiMap

### DIFF
--- a/galileo-egui/src/egui_map.rs
+++ b/galileo-egui/src/egui_map.rs
@@ -136,7 +136,7 @@ impl<'a> EguiMapState {
     }
 
     pub fn render(&mut self, ui: &mut egui::Ui) {
-        let available_size = ui.available_size();
+        let available_size = ui.available_size().floor();
         let map_size = self.renderer.size().cast::<f32>();
 
         let (rect, response) = ui.allocate_exact_size(available_size, Sense::click_and_drag());


### PR DESCRIPTION
I was trying to get CPU usage down on a demo app I'm working on and found that  `ui.available_size()` was returning a `Vec2` with nonzero fractional parts in `EguiMap::render`, which caused it to fail the test to see if it was taking all available space and thus triggered a redraw. 

Calling `floor()` on the resulting Vec2 resolved it for me, although it might be better to just convert the dimensions to integer types.