### PR TITLE
Remove default symbols from vector tile style

### DIFF
--- a/galileo/examples/data/vt_style.json
+++ b/galileo/examples/data/vt_style.json
@@ -210,20 +210,30 @@
           }
         }
       }
+    },
+    {
+      "symbol": {
+        "line": {
+          "stroke_color": "#e0e0e0ff",
+          "width": 1.5
+        }
+      }
+    },
+    {
+      "symbol": {
+        "polygon": {
+          "fill_color": "#e0e0e0ff"
+        }
+      }
+    },
+    {
+      "symbol": {
+        "point": {
+          "size": 2.4,
+          "color": "#ff0000ff"
+        }
+      }
     }
   ],
-  "default_symbol": {
-    "line": {
-      "stroke_color": "#e0e0e0ff",
-      "width": 1.0
-    },
-    "polygon": {
-      "fill_color": "#e0e0e0ff"
-    },
-    "point": {
-      "size": 2.4,
-      "color": "#ff0000ff"
-    }
-  },
   "background": "#fff3e4"
 }

--- a/galileo/examples/vector_tiles_labels.rs
+++ b/galileo/examples/vector_tiles_labels.rs
@@ -1,7 +1,7 @@
 //! This examples shows how to render labels for vector tile points.
 
 use galileo::layer::vector_tile_layer::style::{
-    VectorTileDefaultSymbol, VectorTileLabelSymbol, VectorTileStyle,
+    StyleRule, VectorTileLabelSymbol, VectorTileStyle, VectorTileSymbol,
 };
 use galileo::layer::vector_tile_layer::{VectorTileLayer, VectorTileLayerBuilder};
 use galileo::render::text::text_service::TextService;
@@ -42,10 +42,11 @@ pub(crate) fn run() {
     .expect("failed to create layer");
 
     let labels_style = VectorTileStyle {
-        rules: vec![],
-        default_symbol: VectorTileDefaultSymbol {
-            label: Some(VectorTileLabelSymbol {
-                pattern: "{name}".into(),
+        rules: vec![StyleRule {
+            layer_name: None,
+            properties: Default::default(),
+            symbol: VectorTileSymbol::Label(VectorTileLabelSymbol {
+                pattern: String::from("{name}"),
                 text_style: TextStyle {
                     font_family: vec![
                         "Noto Sans".to_string(),
@@ -65,8 +66,7 @@ pub(crate) fn run() {
                     outline_color: Color::WHITE,
                 },
             }),
-            ..Default::default()
-        },
+        }],
         background: Default::default(),
     };
 

--- a/galileo/src/layer/vector_tile_layer/builder.rs
+++ b/galileo/src/layer/vector_tile_layer/builder.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 
 use super::style::{
-    VectorTileDefaultSymbol, VectorTileLineSymbol, VectorTilePolygonSymbol, VectorTileStyle,
+    StyleRule, VectorTileLineSymbol, VectorTilePolygonSymbol, VectorTileStyle, VectorTileSymbol,
 };
 use super::tile_provider::loader::WebVtLoader;
 use super::tile_provider::processor::VectorTileProcessor;
@@ -417,18 +417,23 @@ impl VectorTileLayerBuilder {
 
     fn default_style() -> VectorTileStyle {
         VectorTileStyle {
-            rules: vec![],
-            default_symbol: VectorTileDefaultSymbol {
-                point: None,
-                line: Some(VectorTileLineSymbol {
-                    width: 1.0,
-                    stroke_color: Color::BLACK,
-                }),
-                polygon: Some(VectorTilePolygonSymbol {
-                    fill_color: Color::GRAY,
-                }),
-                label: None,
-            },
+            rules: vec![
+                StyleRule {
+                    layer_name: None,
+                    properties: Default::default(),
+                    symbol: VectorTileSymbol::Line(VectorTileLineSymbol {
+                        width: 1.0,
+                        stroke_color: Color::BLACK,
+                    }),
+                },
+                StyleRule {
+                    layer_name: None,
+                    properties: Default::default(),
+                    symbol: VectorTileSymbol::Polygon(VectorTilePolygonSymbol {
+                        fill_color: Color::GRAY,
+                    }),
+                },
+            ],
             background: Color::WHITE,
         }
     }


### PR DESCRIPTION
These can be easily implemented by style rules without filters at the end of style rule list, so this duplication is redundant.

Fixes #131 