### PR TITLE
propagate DragEnd from button releases

### DIFF
--- a/galileo/src/control/event_processor.rs
+++ b/galileo/src/control/event_processor.rs
@@ -151,7 +151,7 @@ impl EventProcessor {
                     self.last_click_time = now;
                 }
 
-                if self.drag_target.take().is_some() {
+                if self.drag_target.is_some() {
                     events.push(UserEvent::DragEnded(button, self.get_mouse_event()));
                 }
 


### PR DESCRIPTION
This PR fixes UserEvent::DragEnded not being propagated from ButtonReleases to user event handlers.

NOTE: `.take()` on an Option replaces its current value with `None`, therefore the [processing filter](https://github.com/Maximkaaa/galileo/blob/fd95eb25f20a56d83753f135ce609d59a7033bea/galileo/src/control/event_processor.rs#L90) would skip these events as `drag_target` was already reset at that time.

I hope `take` was not intentional here... 