### PR TITLE
opt: Refactor and optimize VT style rule checks

### DIFF
--- a/galileo-mvt/src/lib.rs
+++ b/galileo-mvt/src/lib.rs
@@ -68,6 +68,20 @@ impl DisplayStr for MvtValue {
     }
 }
 
+impl MvtValue {
+    pub fn eq_str(&self, str_value: &str) -> bool {
+        match &self {
+            MvtValue::String(s) => s == str_value,
+            MvtValue::Float(v) => str_value.parse::<f32>() == Ok(*v),
+            MvtValue::Double(v) => str_value.parse::<f64>() == Ok(*v),
+            MvtValue::Int64(v) => str_value.parse::<i64>() == Ok(*v),
+            MvtValue::Uint64(v) => str_value.parse::<u64>() == Ok(*v),
+            MvtValue::Bool(v) => str_value.parse::<bool>() == Ok(*v),
+            MvtValue::Unknown => false,
+        }
+    }
+}
+
 pub type Point = Point2<f32>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/galileo/src/layer/vector_tile_layer/style.rs
+++ b/galileo/src/layer/vector_tile_layer/style.rs
@@ -49,16 +49,16 @@ impl VectorTileStyle {
                 return false;
             }
 
-            let layer_name_check_passed = match &rule.layer_name {
-                Some(name) => name == layer_name,
-                None => true,
-            };
-            layer_name_check_passed
-                && (rule.properties.is_empty()
-                    || rule.properties.iter().all(|(key, value)| {
-                        feature.properties.get(key).map(|v| v.to_string())
-                            == Some(value.to_string())
-                    }))
+            if rule.layer_name.as_ref().is_some_and(|v| v != layer_name) {
+                return false;
+            }
+
+            let filter_check_passed = rule
+                .properties
+                .iter()
+                .all(|(key, value)| feature.properties.get(key).is_some_and(|v| v.eq_str(value)));
+
+            filter_check_passed
         })
     }
 }


### PR DESCRIPTION
Removed all string allocations when checking if a vector tile styling rule is applied or not.