### PR TITLE
chore: release v0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2021"
 keywords = ["gis", "map", "rendering"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Maximkaaa/galileo"
-version = "0.2.0"
+version = "0.2.1"
 
 [workspace.lints]
 rust.missing_docs = "warn"
@@ -62,10 +62,10 @@ font-kit = "0.14"
 font-query = { git = "https://github.com/Maximkaaa/font-query" }
 futures = "0.3"
 futures-intrusive = "0.5"
-galileo = { path = "galileo", version = "0.2.0" }
-galileo-egui = { path = "galileo-egui", version = "0.2.0" }
-galileo-mvt = { path = "galileo-mvt", version = "0.2.0" }
-galileo-types = { path = "galileo-types", version = "0.2.0" }
+galileo = { path = "galileo", version = "0.2.1" }
+galileo-egui = { path = "galileo-egui", version = "0.2.1" }
+galileo-mvt = { path = "galileo-mvt", version = "0.2.1" }
+galileo-types = { path = "galileo-types", version = "0.2.1" }
 geo = "0.27"
 geodesy = "0.13"
 geojson = "0.24"

--- a/galileo-egui/CHANGELOG.md
+++ b/galileo-egui/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/Maximkaaa/galileo/compare/galileo-egui-v0.2.0...galileo-egui-v0.2.1) - 2025-06-26
+
+### Other
+
+- Update links to web examples in readmy

--- a/galileo-mvt/CHANGELOG.md
+++ b/galileo-mvt/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/Maximkaaa/galileo/compare/galileo-mvt-v0.2.0...galileo-mvt-v0.2.1) - 2025-06-26
+
+### Other
+
+- Update links to web examples in readmy

--- a/galileo-types/CHANGELOG.md
+++ b/galileo-types/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/Maximkaaa/galileo/compare/galileo-types-v0.2.0...galileo-types-v0.2.1) - 2025-06-26
+
+### Other
+
+- Update links to web examples in readmy

--- a/galileo/CHANGELOG.md
+++ b/galileo/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/Maximkaaa/galileo/compare/galileo-v0.2.0...galileo-v0.2.1) - 2025-06-26
+
+### Other
+
+- Fix links RasterTileProvider -> RasterTileLoader in docs
+- Update links to web examples in readmy


### PR DESCRIPTION



## 🤖 New release

* `galileo-types`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `galileo-mvt`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `galileo`: 0.2.0 -> 0.2.1
* `galileo-egui`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `galileo-types`

<blockquote>

## [0.2.1](https://github.com/Maximkaaa/galileo/compare/galileo-types-v0.2.0...galileo-types-v0.2.1) - 2025-06-26

### Other

- Update links to web examples in readmy
</blockquote>

## `galileo-mvt`

<blockquote>

## [0.2.1](https://github.com/Maximkaaa/galileo/compare/galileo-mvt-v0.2.0...galileo-mvt-v0.2.1) - 2025-06-26

### Other

- Update links to web examples in readmy
</blockquote>

## `galileo`

<blockquote>

## [0.2.1](https://github.com/Maximkaaa/galileo/compare/galileo-v0.2.0...galileo-v0.2.1) - 2025-06-26

### Other

- Fix links RasterTileProvider -> RasterTileLoader in docs
- Update links to web examples in readmy
</blockquote>

## `galileo-egui`

<blockquote>

## [0.2.1](https://github.com/Maximkaaa/galileo/compare/galileo-egui-v0.2.0...galileo-egui-v0.2.1) - 2025-06-26

### Other

- Update links to web examples in readmy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).