### PR TITLE
chore: update to egui `0.32`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,9 @@ cfg-if = "1"
 console_log = "1"
 console_error_panic_hook = "0.1"
 csv = "1.3"
-egui = "0.31"
-egui-wgpu = "0.31"
-eframe = { version = "0.31", default-features = false }
+egui = "0.32"
+egui-wgpu = "0.32"
+eframe = { version = "0.32", default-features = false }
 env_logger = "0.11"
 fontdb = { version = "0.23", default-features = false }
 font-kit = "0.14"
@@ -102,5 +102,5 @@ wasm-bindgen-derive = "0.2"
 wasm-bindgen-futures = "0.4"
 web-time = "1"
 web-sys = "0.3"
-wgpu = { version = "24", default-features = false }
+wgpu = { version = "25", default-features = false, features = ["metal", "wgsl", "webgl", "vulkan", "gles"] }
 winit = { version = "0.30", default-features = false }


### PR DESCRIPTION
Closes #230 

Updates `egui` to `0.32`, along with some minor changes for `wgpu` `25`