### PR TITLE
fix: dragging an `egui::Window` no longer drags the map

### DIFF
--- a/galileo-egui/src/egui_map.rs
+++ b/galileo-egui/src/egui_map.rs
@@ -158,7 +158,7 @@ impl<'a> EguiMapState {
                 });
         }
 
-        if self.event_processor.is_dragging() || response.contains_pointer() {
+        if self.event_processor.is_dragging() || response.hovered() {
             let events = ui.input(|input_state| input_state.events.clone());
             self.process_events(&events, [-rect.left(), -rect.top()]);
         }


### PR DESCRIPTION
Use `hovered` instead of `contains_pointer`  as it returns false when another widget is being dragged

Closes #215 