### PR TITLE
feat(egui): Pass `CreationContext` to `AppBuilder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Most of the Galileo examples can be run in browser. You will need to have `wasm_
 on your system:
 
 ```shell
-just web_example <example_name>
+just run_web_example <example_name>
 ```
 
 Then just open `localhost:8000` in your browser.
@@ -182,7 +182,7 @@ comes with additional advantages:
 * Increase development speed.
 * Make your needs our priority.
 * See your logo on the project's page.
-* 
+*
 
 ## Current sponsors
 

--- a/galileo-egui/src/init.rs
+++ b/galileo-egui/src/init.rs
@@ -1,4 +1,4 @@
-use eframe::AppCreator;
+use eframe::{AppCreator, CreationContext};
 use galileo::control::UserEventHandler;
 use galileo::render::HorizonOptions;
 use galileo::Map;
@@ -17,7 +17,7 @@ impl eframe::App for MapApp {
     }
 }
 
-type AppBuilder = Box<dyn FnOnce(EguiMapState) -> Box<dyn eframe::App>>;
+type AppBuilder = Box<dyn FnOnce(EguiMapState, &CreationContext<'_>) -> Box<dyn eframe::App>>;
 
 pub struct InitBuilder {
     map: Map,
@@ -80,7 +80,7 @@ impl InitBuilder {
 
     pub fn with_app_builder(
         mut self,
-        app_builder: impl FnOnce(EguiMapState) -> Box<dyn eframe::App> + 'static,
+        app_builder: impl FnOnce(EguiMapState, &CreationContext<'_>) -> Box<dyn eframe::App> + 'static,
     ) -> Self {
         self.app_builder = Some(Box::new(app_builder));
         self
@@ -205,12 +205,12 @@ fn app_creator<'app>(
             .expect("failed to get wgpu context");
         let egui_map_state = EguiMapState::new(map, ctx, render_state, handlers, options);
         let app = app_builder.unwrap_or_else(|| {
-            Box::new(|egui_map_state: EguiMapState| {
+            Box::new(|egui_map_state: EguiMapState, _: &CreationContext<'_>| {
                 Box::new(MapApp {
                     map: egui_map_state,
                 })
             })
-        })(egui_map_state);
+        })(egui_map_state, cc);
         Ok(app)
     })
 }

--- a/galileo-egui/src/init.rs
+++ b/galileo-egui/src/init.rs
@@ -1,4 +1,4 @@
-use eframe::{AppCreator, CreationContext};
+use eframe::AppCreator;
 use galileo::control::UserEventHandler;
 use galileo::render::HorizonOptions;
 use galileo::Map;
@@ -17,7 +17,8 @@ impl eframe::App for MapApp {
     }
 }
 
-type AppBuilder = Box<dyn FnOnce(EguiMapState, &CreationContext<'_>) -> Box<dyn eframe::App>>;
+type AppBuilder =
+    Box<dyn FnOnce(EguiMapState, &eframe::CreationContext<'_>) -> Box<dyn eframe::App>>;
 
 pub struct InitBuilder {
     map: Map,
@@ -80,7 +81,8 @@ impl InitBuilder {
 
     pub fn with_app_builder(
         mut self,
-        app_builder: impl FnOnce(EguiMapState, &CreationContext<'_>) -> Box<dyn eframe::App> + 'static,
+        app_builder: impl FnOnce(EguiMapState, &eframe::CreationContext<'_>) -> Box<dyn eframe::App>
+            + 'static,
     ) -> Self {
         self.app_builder = Some(Box::new(app_builder));
         self
@@ -205,11 +207,13 @@ fn app_creator<'app>(
             .expect("failed to get wgpu context");
         let egui_map_state = EguiMapState::new(map, ctx, render_state, handlers, options);
         let app = app_builder.unwrap_or_else(|| {
-            Box::new(|egui_map_state: EguiMapState, _: &CreationContext<'_>| {
-                Box::new(MapApp {
-                    map: egui_map_state,
-                })
-            })
+            Box::new(
+                |egui_map_state: EguiMapState, _: &eframe::CreationContext<'_>| {
+                    Box::new(MapApp {
+                        map: egui_map_state,
+                    })
+                },
+            )
         })(egui_map_state, cc);
         Ok(app)
     })

--- a/galileo/examples/egui_app.rs
+++ b/galileo/examples/egui_app.rs
@@ -1,6 +1,5 @@
 //! Example showing how to integrate Galileo map into your egui application.
 
-use eframe::CreationContext;
 use galileo::layer::raster_tile_layer::RasterTileLayerBuilder;
 use galileo::{Map, MapBuilder};
 use galileo_egui::{EguiMap, EguiMapState};
@@ -23,7 +22,7 @@ struct EguiMapApp {
 }
 
 impl EguiMapApp {
-    fn new(egui_map_state: EguiMapState, cc: &CreationContext<'_>) -> Self {
+    fn new(egui_map_state: EguiMapState, cc: &eframe::CreationContext<'_>) -> Self {
         // get initial position from map
         let initial_position = egui_map_state
             .map()

--- a/galileo/examples/egui_app.rs
+++ b/galileo/examples/egui_app.rs
@@ -33,7 +33,7 @@ impl EguiMapApp {
         // get initial resolution from map
         let initial_resolution = egui_map_state.map().view().resolution();
 
-        // Try to get storaged values or use initial values
+        // Try to get stored values or use initial values
         let AppStorage {
             position,
             resolution,

--- a/galileo/examples/egui_app.rs
+++ b/galileo/examples/egui_app.rs
@@ -8,8 +8,7 @@ use galileo_types::geo::GeoPoint;
 
 const STORAGE_KEY: &str = "galileo_egui_app_example";
 
-#[derive(serde::Deserialize, serde::Serialize, Default)]
-#[serde(default)]
+#[derive(serde::Deserialize, serde::Serialize)]
 struct AppStorage {
     position: GeoPoint2d,
     resolution: f64,

--- a/galileo/examples/egui_app.rs
+++ b/galileo/examples/egui_app.rs
@@ -1,10 +1,20 @@
 //! Example showing how to integrate Galileo map into your egui application.
 
+use eframe::CreationContext;
 use galileo::layer::raster_tile_layer::RasterTileLayerBuilder;
 use galileo::{Map, MapBuilder};
 use galileo_egui::{EguiMap, EguiMapState};
 use galileo_types::geo::impls::GeoPoint2d;
 use galileo_types::geo::GeoPoint;
+
+const STORAGE_KEY: &str = "galileo_egui_app_example";
+
+#[derive(serde::Deserialize, serde::Serialize, Default)]
+#[serde(default)]
+struct AppStorage {
+    position: GeoPoint2d,
+    resolution: f64,
+}
 
 struct EguiMapApp {
     map: EguiMapState,
@@ -13,13 +23,27 @@ struct EguiMapApp {
 }
 
 impl EguiMapApp {
-    fn new(egui_map_state: EguiMapState) -> Self {
-        let position = egui_map_state
+    fn new(egui_map_state: EguiMapState, cc: &CreationContext<'_>) -> Self {
+        // get initial position from map
+        let initial_position = egui_map_state
             .map()
             .view()
             .position()
             .expect("invalid map position");
-        let resolution = egui_map_state.map().view().resolution();
+        // get initial resolution from map
+        let initial_resolution = egui_map_state.map().view().resolution();
+
+        // Try to get storaged values or use initial values
+        let AppStorage {
+            position,
+            resolution,
+        } = cc
+            .storage
+            .and_then(|storage| eframe::get_value(storage, STORAGE_KEY))
+            .unwrap_or(AppStorage {
+                position: initial_position,
+                resolution: initial_resolution,
+            });
 
         Self {
             map: egui_map_state,
@@ -51,6 +75,18 @@ impl eframe::App for EguiMapApp {
             });
         });
     }
+
+    // Called by egui to save state before shutdown.
+    fn save(&mut self, storage: &mut dyn eframe::Storage) {
+        eframe::set_value(
+            storage,
+            STORAGE_KEY,
+            &AppStorage {
+                position: self.position,
+                resolution: self.resolution,
+            },
+        );
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -61,7 +97,7 @@ fn main() {
 pub(crate) fn run() {
     let map = create_map();
     galileo_egui::InitBuilder::new(map)
-        .with_app_builder(|egui_map_state| Box::new(EguiMapApp::new(egui_map_state)))
+        .with_app_builder(|egui_map_state, cc| Box::new(EguiMapApp::new(egui_map_state, cc)))
         .init()
         .expect("failed to initialize");
 }

--- a/galileo/examples/labels.rs
+++ b/galileo/examples/labels.rs
@@ -235,7 +235,7 @@ pub(crate) fn run() {
     initialize_font_service();
     let map = create_map();
     galileo_egui::InitBuilder::new(map)
-        .with_app_builder(|egui_map_state| Box::new(EguiMapApp::new(egui_map_state)))
+        .with_app_builder(|egui_map_state, _| Box::new(EguiMapApp::new(egui_map_state)))
         .init()
         .expect("failed to initialize");
 }

--- a/galileo/examples/vector_tiles.rs
+++ b/galileo/examples/vector_tiles.rs
@@ -121,7 +121,7 @@ pub(crate) fn run() {
     let map = MapBuilder::default().with_layer(layer.clone()).build();
     galileo_egui::InitBuilder::new(map)
         .with_handlers([Box::new(handler) as Box<dyn UserEventHandler>])
-        .with_app_builder(|egui_map_state| Box::new(App::new(egui_map_state, layer)))
+        .with_app_builder(|egui_map_state, _| Box::new(App::new(egui_map_state, layer)))
         .init()
         .expect("failed to initialize");
 }


### PR DESCRIPTION
Provide [`CreationContext`](https://docs.rs/eframe/latest/eframe/struct.CreationContext.html) in `AppBuilder` to setup and initialize an app with an `egui` context. 

For example to provide `eframe`'s [`Storage`](https://docs.rs/eframe/latest/eframe/trait.Storage.html) feature - see updated `egui_app.rs`. 

<img width="756" height="581" alt="egui_app_local_storage" src="https://github.com/user-attachments/assets/fe90af5f-8bba-4e7b-8f53-3c329bb4e1e3" />

