### PR TITLE
feat(egui): set custom `app_name` (optional)

### DIFF
--- a/galileo-egui/src/init.rs
+++ b/galileo-egui/src/init.rs
@@ -29,6 +29,7 @@ pub struct InitBuilder {
     app_builder: Option<AppBuilder>,
     logging: bool,
     options: EguiMapOptions,
+    #[cfg(not(target_arch = "wasm32"))]
     app_name: Option<String>,
 }
 
@@ -56,6 +57,7 @@ impl InitBuilder {
             app_builder: None,
             logging: true,
             options: Default::default(),
+            #[cfg(not(target_arch = "wasm32"))]
             app_name: None,
         }
     }

--- a/galileo-egui/src/init.rs
+++ b/galileo-egui/src/init.rs
@@ -144,7 +144,7 @@ impl InitBuilder {
         let app_creator: AppCreator<'static> =
             app_creator(self.map, handlers, self.app_builder, self.options);
 
-        let app_name: &str = self.app_name.as_deref().unwrap_or("Galileo Dev Map");
+        let app_name: &str = self.app_name.as_deref().unwrap_or("Galileo Map App");
 
         eframe::run_native(app_name, native_options, app_creator)
     }

--- a/galileo-egui/src/init.rs
+++ b/galileo-egui/src/init.rs
@@ -29,6 +29,7 @@ pub struct InitBuilder {
     app_builder: Option<AppBuilder>,
     logging: bool,
     options: EguiMapOptions,
+    app_name: Option<String>,
 }
 
 pub struct EguiMapOptions {
@@ -55,6 +56,7 @@ impl InitBuilder {
             app_builder: None,
             logging: true,
             options: Default::default(),
+            app_name: None,
         }
     }
 
@@ -93,6 +95,12 @@ impl InitBuilder {
 
     pub fn with_horizon_options(mut self, options: Option<HorizonOptions>) -> Self {
         self.options.horizon_options = options;
+        self
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn with_app_name(mut self, app_name: &str) -> Self {
+        self.app_name = Some(app_name.to_owned());
         self
     }
 
@@ -136,7 +144,9 @@ impl InitBuilder {
         let app_creator: AppCreator<'static> =
             app_creator(self.map, handlers, self.app_builder, self.options);
 
-        eframe::run_native("Galileo Dev Map", native_options, app_creator)
+        let app_name: &str = self.app_name.as_deref().unwrap_or("Galileo Dev Map");
+
+        eframe::run_native(app_name, native_options, app_creator)
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/galileo/examples/egui_app.rs
+++ b/galileo/examples/egui_app.rs
@@ -60,11 +60,16 @@ fn main() {
 
 pub(crate) fn run() {
     let map = create_map();
-    galileo_egui::InitBuilder::new(map)
-        .with_app_builder(|egui_map_state| Box::new(EguiMapApp::new(egui_map_state)))
-        .with_app_name("galileo egui app")
-        .init()
-        .expect("failed to initialize");
+
+    let mut builder = galileo_egui::InitBuilder::new(map)
+        .with_app_builder(|egui_map_state| Box::new(EguiMapApp::new(egui_map_state)));
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        builder = builder.with_app_name("galileo egui app")
+    }
+
+    builder.init().expect("failed to initialize");
 }
 
 fn create_map() -> Map {

--- a/galileo/examples/egui_app.rs
+++ b/galileo/examples/egui_app.rs
@@ -62,6 +62,7 @@ pub(crate) fn run() {
     let map = create_map();
     galileo_egui::InitBuilder::new(map)
         .with_app_builder(|egui_map_state| Box::new(EguiMapApp::new(egui_map_state)))
+        .with_app_name("galileo egui app")
         .init()
         .expect("failed to initialize");
 }


### PR DESCRIPTION
`with_app_name` provides an option to set the name of the app. Internally it will passed to `eframe::run_native`.

From [`eframe::run_native`](https://docs.rs/eframe/latest/eframe/fn.run_native.html) documentation:

> The first argument is name of your app, which is an identifier used for the save location of persistence (see [App::save](https://docs.rs/eframe/latest/eframe/trait.App.html#method.save)). It is also used as the application id on wayland. If you set no title on the viewport, the app id will be used as the title.