### PR TITLE
fix(cache): remove url query params from file path

### DIFF
--- a/galileo/src/layer/data_provider/file_cache.rs
+++ b/galileo/src/layer/data_provider/file_cache.rs
@@ -65,18 +65,43 @@ impl FileCacheController {
     }
 
     fn get_file_path(&self, url: &str) -> PathBuf {
-        let stripped = if let Some(v) = url.strip_prefix("http://") {
-            v
-        } else if let Some(v) = url.strip_prefix("https://") {
-            v
-        } else {
-            url
-        };
-
-        self.folder_path.join(Path::new(stripped))
+        let path = path_from_url(url);
+        self.folder_path.join(path)
     }
 }
 
 fn ensure_folder_exists(folder_path: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(folder_path)
+}
+
+fn path_from_url(url: &str) -> &Path {
+    // strip `http` or `https` from url
+    let path = ["http://", "https://"]
+        .iter()
+        .find_map(|prefix| url.strip_prefix(prefix))
+        .unwrap_or(url)
+        // strip query parameters if any
+        .split('?')
+        .next()
+        .unwrap_or(url);
+    Path::new(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_path_from_url() {
+        let path1 = path_from_url("http://api.maptiler.com/tiles/id/1/2/3.png");
+        let path2 = path_from_url("https://api.maptiler.com/tiles/id/1/2/3.png");
+        let path3 = path_from_url("http://api.maptiler.com/tiles/id/1/2/3.png?key=abc");
+        let path4 = path_from_url("https://api.maptiler.com/tiles/id/1/2/3.png?key=abc");
+
+        let expected = Path::new("api.maptiler.com/tiles/id/1/2/3.png");
+        assert_eq!(expected, path1);
+        assert_eq!(expected, path2);
+        assert_eq!(expected, path3);
+        assert_eq!(expected, path4);
+    }
 }


### PR DESCRIPTION
## BEFORE

<img width="404" height="266" alt="file_cache_before" src="https://github.com/user-attachments/assets/0678bd5e-85d9-4564-a1f4-f72bc667bcbb" />


## FIXED

<img width="404" height="266" alt="file_cache_after" src="https://github.com/user-attachments/assets/c790b5cf-8c88-4227-af7b-b74d804e60f0" />


