### PR TITLE
feat(example) switch tile layers at runtime

### DIFF
--- a/galileo-egui/src/egui_map.rs
+++ b/galileo-egui/src/egui_map.rs
@@ -145,6 +145,7 @@ pub struct EguiMapState {
     texture_id: TextureId,
     texture_view: TextureView,
     event_processor: EventProcessor,
+    messenger: MapStateMessenger,
 }
 
 impl<'a> EguiMapState {
@@ -207,6 +208,7 @@ impl<'a> EguiMapState {
             texture_id,
             texture_view: texture,
             event_processor,
+            messenger,
         }
     }
 
@@ -300,6 +302,11 @@ impl<'a> EguiMapState {
     /// Returns a mutable reference to the Galileo map instance.
     pub fn map_mut(&'a mut self) -> &'a mut Map {
         &mut self.map
+    }
+
+    /// Returns event messenger that is used by the map.
+    pub fn messenger(&self) -> impl Messenger {
+        self.messenger.clone()
     }
 
     fn resize_map(&mut self, size: Vec2) {

--- a/galileo/examples/raster_tiles_switch.rs
+++ b/galileo/examples/raster_tiles_switch.rs
@@ -1,0 +1,90 @@
+//! This example shows how to switch tile layers at runtime.
+
+use galileo::layer::raster_tile_layer::RasterTileLayerBuilder;
+use galileo::layer::RasterTileLayer;
+use galileo::tile_schema::TileIndex;
+use galileo::MapBuilder;
+use galileo_egui::{EguiMap, EguiMapState};
+
+struct App {
+    map: EguiMapState,
+}
+
+impl App {
+    fn new(egui_map_state: EguiMapState) -> Self {
+        Self {
+            map: egui_map_state,
+        }
+    }
+
+    fn switch_layer(&mut self, tile_id: &str) {
+        let layers = self.map.map_mut().layers_mut();
+        // because we know to have one layer and at index 0 only, it's save to remove it using that index
+        layers.remove(0);
+        // create a new layer
+        let layer = build_layer(tile_id);
+        // add that layer
+        layers.push(layer);
+        // re-render the map
+        self.map.request_redraw();
+    }
+}
+
+impl eframe::App for App {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            EguiMap::new(&mut self.map).show_ui(ui);
+        });
+
+        egui::Window::new("Buttons")
+            .title_bar(false)
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    if ui.button("winter").clicked() {
+                        self.switch_layer("winter-v2");
+                    }
+                    if ui.button("streets").clicked() {
+                        self.switch_layer("streets-v2");
+                    }
+                });
+            });
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+    run()
+}
+
+pub(crate) fn run() {
+    let layer = build_layer("streets-v2");
+
+    let map = MapBuilder::default()
+        .with_latlon(37.566, 128.9784)
+        .with_z_level(8)
+        .with_layer(layer)
+        .build();
+
+    galileo_egui::InitBuilder::new(map)
+        .with_app_builder(|egui_map_state, _| Box::new(App::new(egui_map_state)))
+        .init()
+        .expect("failed to initialize");
+}
+
+fn build_layer(tile_id: &str) -> RasterTileLayer {
+    let Some(api_key) = std::option_env!("VT_API_KEY") else {
+        panic!("Set the MapTiler API key into VT_API_KEY library when building this example");
+    };
+    let tile_id = tile_id.to_owned();
+    RasterTileLayerBuilder::new_rest(move |&index: &TileIndex| {
+        format!(
+            "https://api.maptiler.com/maps/{tile_id}/{z}/{x}/{y}.png?key={api_key}",
+            z = index.z,
+            x = index.x,
+            y = index.y
+        )
+    })
+    .with_file_cache_checked(".tile_cache")
+    .build()
+    .expect("failed to create layer")
+}


### PR DESCRIPTION
**_WIP_**

```sh
VT_API_KEY=your-maptile-api-key cargo run --example raster_tiles_switch
```

Following issue: After switching the layers, the map needs to be "moved" to fade in the new layer. What I'm missing here?

[switch-layer-issue.webm](https://github.com/user-attachments/assets/4ad3c140-49d4-494c-af79-0a52644141e6)
