### PR TITLE
fix(tiles): fade `raster` tiles only once

### DIFF
--- a/galileo/src/layer/vector_tile_layer/tile_provider/mod.rs
+++ b/galileo/src/layer/vector_tile_layer/tile_provider/mod.rs
@@ -8,7 +8,7 @@ use loader::VectorTileLoader;
 use parking_lot::RwLock;
 use processor::VectorTileProcessor;
 
-use crate::layer::tiles::TileProvider;
+use crate::layer::tiles::{RenderedState, TileProvider};
 use crate::layer::vector_tile_layer::style::VectorTileStyle;
 use crate::messenger::Messenger;
 use crate::render::{Canvas, PackedBundle};
@@ -59,6 +59,16 @@ impl TileProvider<VtStyleId> for VectorTileProvider {
     fn get_tile(&self, index: TileIndex, style_id: VtStyleId) -> Option<Arc<dyn PackedBundle>> {
         VectorTileProvider::get_tile(self, index, style_id)
     }
+
+    fn get_rendered_state(&self, index: TileIndex, style_id: VtStyleId) -> Option<RenderedState> {
+        // TODO: implement `rendered_before` for vector tiles (if needed/possible)
+        self.get_tile(index, style_id).map(|bundle| RenderedState {
+            bundle,
+            rendered_before: false,
+        })
+    }
+
+    fn set_rendered_before(&self, _index: TileIndex, _style_id: VtStyleId) {}
 }
 
 impl VectorTileProvider {


### PR DESCRIPTION
and at initial (first) load only. In other case we have tiles already in cache, no need to fade again.

## BEFORE
By moving the map all tiles always fading in.

[before_fade.webm](https://github.com/user-attachments/assets/a1b5302d-acea-4fa5-a732-8dba74380d9e)

## FIXED
Fading for initial load of tiles only. Already loaded tiles don't fade anymore.

[fixed_fade.webm](https://github.com/user-attachments/assets/6701e4c8-44b7-4c5e-9c67-75d4405e8252)
