### PR TITLE
Do not duplicate same tiles in memory

### DIFF
--- a/galileo/src/layer/feature_layer/bundle_store.rs
+++ b/galileo/src/layer/feature_layer/bundle_store.rs
@@ -77,7 +77,10 @@ impl BundleStore {
     }
 
     pub(super) fn packed(&self) -> Vec<BundleToDraw> {
-        self.packed.values().map(|v| BundleToDraw::with_opacity(&**v, 1.0)).collect()
+        self.packed
+            .values()
+            .map(|v| BundleToDraw::with_opacity(&**v, 1.0))
+            .collect()
     }
 
     pub(super) fn set_bundle_size_limit(&mut self, limit: usize) {

--- a/galileo/src/layer/feature_layer/bundle_store.rs
+++ b/galileo/src/layer/feature_layer/bundle_store.rs
@@ -4,7 +4,7 @@ use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 
 use super::FeatureId;
 use crate::render::render_bundle::RenderBundle;
-use crate::render::{Canvas, PackedBundle};
+use crate::render::{BundleToDraw, Canvas, PackedBundle};
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub(super) struct BundleId(u64);
@@ -76,8 +76,8 @@ impl BundleStore {
         self.required_update.updated();
     }
 
-    pub(super) fn packed(&self) -> Vec<&dyn PackedBundle> {
-        self.packed.values().map(|v| &**v).collect()
+    pub(super) fn packed(&self) -> Vec<BundleToDraw> {
+        self.packed.values().map(|v| BundleToDraw::with_opacity(&**v, 1.0)).collect()
     }
 
     pub(super) fn set_bundle_size_limit(&mut self, limit: usize) {

--- a/galileo/src/layer/raster_tile_layer/mod.rs
+++ b/galileo/src/layer/raster_tile_layer/mod.rs
@@ -10,7 +10,7 @@ use super::tiles::TilesContainer;
 use super::Layer;
 use crate::layer::attribution::Attribution;
 use crate::messenger::Messenger;
-use crate::render::{Canvas, RenderOptions};
+use crate::render::{BundleToDraw, Canvas, RenderOptions};
 use crate::tile_schema::{TileIndex, TileSchema};
 use crate::view::MapView;
 
@@ -155,10 +155,10 @@ impl Layer for RasterTileLayer {
         let displayed_tiles = self.tile_container.tiles.lock();
         let to_render: Vec<_> = displayed_tiles
             .iter()
-            .map(|v| (&*v.bundle, v.opacity))
+            .map(|v| BundleToDraw::with_opacity(&*v.bundle, v.opacity))
             .collect();
 
-        canvas.draw_bundles_with_opacity(&to_render, RenderOptions::default());
+        canvas.draw_bundles(&to_render, RenderOptions::default());
     }
 
     fn prepare(&self, view: &MapView) {

--- a/galileo/src/layer/raster_tile_layer/provider.rs
+++ b/galileo/src/layer/raster_tile_layer/provider.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use galileo_types::cartesian::Rect;
 use maybe_sync::{MaybeSend, MaybeSync};
 use parking_lot::Mutex;
 use quick_cache::sync::Cache;
@@ -167,10 +168,12 @@ impl RasterTileProvider {
         let tiles = self.tiles.lock();
         for index in indices {
             if let Some(TileState::Loaded(image)) = tiles.get(index) {
-                let Some(tile_bbox) = self.tile_schema.tile_bbox(*index) else {
-                    log::warn!("Failed to get bbox for tile {index:?}");
+                let Some(resolution) = self.tile_schema.lod_resolution(index.z) else {
                     continue;
                 };
+                let width = self.tile_schema.tile_width() as f64;
+                let height = self.tile_schema.tile_height() as f64;
+                let tile_bbox = Rect::new(0.0, 0.0, width * resolution, -height * resolution);
 
                 let mut bundle = RenderBundle::default();
                 bundle.add_image(

--- a/galileo/src/layer/tiles.rs
+++ b/galileo/src/layer/tiles.rs
@@ -4,12 +4,12 @@ use std::time::Duration;
 use parking_lot::Mutex;
 
 use crate::render::PackedBundle;
-use crate::tile_schema::TileIndex;
+use crate::tile_schema::{TileIndex, WrappingTileIndex};
 use crate::TileSchema;
 
 #[derive(Clone)]
 pub(crate) struct DisplayedTile<StyleId: Copy> {
-    pub(crate) index: TileIndex,
+    pub(crate) index: WrappingTileIndex,
     pub(crate) bundle: Arc<dyn PackedBundle>,
     style_id: StyleId,
     pub(crate) opacity: f32,
@@ -51,7 +51,7 @@ where
 
     pub(crate) fn update_displayed_tiles(
         &self,
-        needed_indices: impl IntoIterator<Item = TileIndex>,
+        needed_indices: impl IntoIterator<Item = WrappingTileIndex>,
         style_id: StyleId,
     ) -> bool {
         let mut displayed_tiles = self.tiles.lock();
@@ -78,7 +78,7 @@ where
 
                 needed_tiles.push(displayed.clone());
             } else {
-                match self.tile_provider.get_tile(index, style_id) {
+                match self.tile_provider.get_tile(index.into(), style_id) {
                     None => to_substitute.push(index),
                     Some(bundle) => {
                         needed_tiles.push(DisplayedTile {

--- a/galileo/src/layer/tiles.rs
+++ b/galileo/src/layer/tiles.rs
@@ -9,7 +9,7 @@ use crate::TileSchema;
 
 #[derive(Clone)]
 pub(crate) struct DisplayedTile<StyleId: Copy> {
-    index: TileIndex,
+    pub(crate) index: TileIndex,
     pub(crate) bundle: Arc<dyn PackedBundle>,
     style_id: StyleId,
     pub(crate) opacity: f32,

--- a/galileo/src/layer/vector_tile_layer/mod.rs
+++ b/galileo/src/layer/vector_tile_layer/mod.rs
@@ -69,12 +69,17 @@ impl Layer for VectorTileLayer {
         };
 
         let displayed_tiles = self.displayed_tiles.tiles.lock();
-        let to_render: Vec<_> = std::iter::once(BundleToDraw::with_opacity(&*background_bundle, 1.0))
-            .chain(displayed_tiles.iter().filter_map(|v| {
-                let bbox = self.tile_schema.tile_bbox(v.index)?;
-                Some(BundleToDraw::new(&*v.bundle, v.opacity, Vector2::new(bbox.x_min() as f32, bbox.y_max() as f32)))
-            }))
-            .collect();
+        let to_render: Vec<_> =
+            std::iter::once(BundleToDraw::with_opacity(&*background_bundle, 1.0))
+                .chain(displayed_tiles.iter().filter_map(|v| {
+                    let bbox = self.tile_schema.tile_bbox(v.index)?;
+                    Some(BundleToDraw::new(
+                        &*v.bundle,
+                        v.opacity,
+                        Vector2::new(bbox.x_min() as f32, bbox.y_max() as f32),
+                    ))
+                }))
+                .collect();
 
         canvas.draw_bundles(&to_render, RenderOptions::default());
     }

--- a/galileo/src/layer/vector_tile_layer/tile_provider/vt_processor.rs
+++ b/galileo/src/layer/vector_tile_layer/tile_provider/vt_processor.rs
@@ -102,9 +102,7 @@ impl VtProcessor {
                                     &galileo_types::impls::Contour::new(
                                         contour
                                             .iter_points()
-                                            .map(|p| {
-                                                Self::transform_point(&p, tile_resolution)
-                                            })
+                                            .map(|p| Self::transform_point(&p, tile_resolution))
                                             .collect(),
                                         false,
                                     ),
@@ -174,10 +172,7 @@ impl VtProcessor {
         rule.symbol.polygon().map(|&s| s.into())
     }
 
-    fn transform_polygon(
-        mvt_polygon: &MvtPolygon,
-        tile_resolution: f64,
-    ) -> Polygon<Point3> {
+    fn transform_polygon(mvt_polygon: &MvtPolygon, tile_resolution: f64) -> Polygon<Point3> {
         let cast = |p| Self::transform_point(&p, tile_resolution);
 
         Polygon {

--- a/galileo/src/render/mod.rs
+++ b/galileo/src/render/mod.rs
@@ -53,7 +53,7 @@ pub trait PackedBundle: MaybeSend + MaybeSync {
     fn as_any(&self) -> &dyn Any;
 }
 
-/// Packed bundle that is ready to be renderred with the given paramters.
+/// Packed bundle that is ready to be renderred with the given parameters.
 pub struct BundleToDraw<'a> {
     bundle: &'a dyn PackedBundle,
     opacity: f32,
@@ -61,7 +61,7 @@ pub struct BundleToDraw<'a> {
 }
 
 impl<'a> BundleToDraw<'a> {
-    /// Packed bundle with offset and opacity speicified.
+    /// Packed bundle with offset and opacity specified.
     pub fn new(bundle: &'a dyn PackedBundle, opacity: f32, offset: Vector2<f32>) -> Self {
         Self {
             bundle,

--- a/galileo/src/render/mod.rs
+++ b/galileo/src/render/mod.rs
@@ -63,7 +63,11 @@ pub struct BundleToDraw<'a> {
 impl<'a> BundleToDraw<'a> {
     /// Packed bundle with offset and opacity speicified.
     pub fn new(bundle: &'a dyn PackedBundle, opacity: f32, offset: Vector2<f32>) -> Self {
-        Self { bundle, opacity, offset }
+        Self {
+            bundle,
+            opacity,
+            offset,
+        }
     }
 
     /// Packed bundle with zero offset.

--- a/galileo/src/render/wgpu/pipelines/clip.rs
+++ b/galileo/src/render/wgpu/pipelines/clip.rs
@@ -71,12 +71,14 @@ impl ClipPipeline {
         buffers: &'a WgpuVertexBuffers,
         render_pass: &mut RenderPass<'a>,
         render_options: RenderOptions,
+        bundle_index: u32,
     ) {
         self.render(
             buffers,
             render_pass,
             Self::CLIP_STENCIL_VALUE,
             render_options,
+            bundle_index,
         );
     }
 
@@ -85,8 +87,15 @@ impl ClipPipeline {
         buffers: &'a WgpuVertexBuffers,
         render_pass: &mut RenderPass<'a>,
         render_options: RenderOptions,
+        bundle_index: u32,
     ) {
-        self.render(buffers, render_pass, Self::UNCLIP_REFERENCE, render_options);
+        self.render(
+            buffers,
+            render_pass,
+            Self::UNCLIP_REFERENCE,
+            render_options,
+            bundle_index,
+        );
     }
 
     fn render<'a>(
@@ -95,6 +104,7 @@ impl ClipPipeline {
         render_pass: &mut RenderPass<'a>,
         stencil_reference: u32,
         render_options: RenderOptions,
+        bundle_index: u32,
     ) {
         if render_options.antialias {
             render_pass.set_pipeline(&self.wgpu_pipeline_antialias);
@@ -105,6 +115,6 @@ impl ClipPipeline {
         render_pass.set_stencil_reference(stencil_reference);
         render_pass.set_vertex_buffer(0, buffers.vertex.slice(..));
         render_pass.set_index_buffer(buffers.index.slice(..), wgpu::IndexFormat::Uint32);
-        render_pass.draw_indexed(0..buffers.index_count, 0, 0..1);
+        render_pass.draw_indexed(0..buffers.index_count, 0, bundle_index..(bundle_index + 1));
     }
 }

--- a/galileo/src/render/wgpu/pipelines/mod.rs
+++ b/galileo/src/render/wgpu/pipelines/mod.rs
@@ -130,7 +130,8 @@ impl Pipelines {
         self.set_bindings(render_pass);
 
         if let Some(clip) = &bundle.clip_area_buffers {
-            self.clip.clip(clip, render_pass, render_options);
+            self.clip
+                .clip(clip, render_pass, render_options, bundle_index);
         }
 
         for image in &bundle.image_buffers {
@@ -148,7 +149,8 @@ impl Pipelines {
         }
 
         if let Some(clip) = &bundle.clip_area_buffers {
-            self.clip.unclip(clip, render_pass, render_options);
+            self.clip
+                .unclip(clip, render_pass, render_options, bundle_index);
         }
 
         if let Some(dot_buffers) = &bundle.dot_buffers {

--- a/galileo/src/render/wgpu/pipelines/screen_set_image.rs
+++ b/galileo/src/render/wgpu/pipelines/screen_set_image.rs
@@ -6,7 +6,7 @@ use wgpu::{BindGroup, BindGroupLayout, Device, RenderPass, RenderPipeline, Textu
 use super::image::WgpuImage;
 use crate::render::render_bundle::screen_set::ScreenSetImageVertex;
 use crate::render::wgpu::pipelines::{default_pipeline_descriptor, default_targets};
-use crate::render::wgpu::ScreenSetInstance;
+use crate::render::wgpu::DisplayInstance;
 
 const INDICES: &[u16] = &[1, 0, 2, 1, 2, 3];
 
@@ -45,7 +45,7 @@ impl ScreenSetImagePipeline {
     ) -> Self {
         let buffers = [
             ScreenSetImageVertex::wgpu_desc(),
-            ScreenSetInstance::wgpu_desc(),
+            DisplayInstance::wgpu_desc(),
         ];
         let shader =
             device.create_shader_module(wgpu::include_wgsl!("./shaders/screen_set_image.wgsl"));

--- a/galileo/src/render/wgpu/pipelines/screen_set_vertex.rs
+++ b/galileo/src/render/wgpu/pipelines/screen_set_vertex.rs
@@ -4,7 +4,7 @@ use wgpu::{BindGroupLayout, Device, RenderPass, RenderPipeline, TextureFormat};
 
 use crate::render::render_bundle::screen_set::ScreenSetVertex;
 use crate::render::wgpu::pipelines::{default_pipeline_descriptor, default_targets};
-use crate::render::wgpu::{ScreenSetInstance, WgpuVertexBuffers};
+use crate::render::wgpu::{DisplayInstance, WgpuVertexBuffers};
 
 pub struct ScreenSetPipeline {
     wgpu_pipeline: RenderPipeline,
@@ -37,7 +37,7 @@ impl ScreenSetPipeline {
         format: TextureFormat,
         map_view_layout: &BindGroupLayout,
     ) -> Self {
-        let buffers = [ScreenSetVertex::wgpu_desc(), ScreenSetInstance::wgpu_desc()];
+        let buffers = [ScreenSetVertex::wgpu_desc(), DisplayInstance::wgpu_desc()];
         let shader = device.create_shader_module(wgpu::include_wgsl!("./shaders/screen_set.wgsl"));
 
         let targets = default_targets(format);

--- a/galileo/src/render/wgpu/pipelines/shaders/dot.wgsl
+++ b/galileo/src/render/wgpu/pipelines/shaders/dot.wgsl
@@ -14,7 +14,7 @@ struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) color: vec4<u32>,
     @location(10) bundle_opacity: f32,
-    @location(11) bundle_offset: vec2<f32>,
+    @location(11) bundle_offset: vec3<f32>,
 }
 
 struct VertexOutput {
@@ -30,7 +30,7 @@ fn vs_main(
     var color = vec4<f32>(model.color) / 255.0;
     color[3] = color[3] * model.bundle_opacity;
     out.color = color;
-    out.clip_position = transform.view_proj * vec4<f32>(model.position.xy + model.bundle_offset, model.position.z, 1.0);
+    out.clip_position = transform.view_proj * vec4<f32>(model.position + model.bundle_offset, 1.0);
 
     return out;
 }

--- a/galileo/src/render/wgpu/pipelines/shaders/dot.wgsl
+++ b/galileo/src/render/wgpu/pipelines/shaders/dot.wgsl
@@ -13,6 +13,8 @@ var<uniform> transform: ViewUniform;
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) color: vec4<u32>,
+    @location(10) bundle_opacity: f32,
+    @location(11) bundle_offset: vec2<f32>,
 }
 
 struct VertexOutput {
@@ -23,13 +25,12 @@ struct VertexOutput {
 @vertex
 fn vs_main(
     model: VertexInput,
-    @location(10) bundle_opacity: f32,
 ) -> VertexOutput {
     var out: VertexOutput;
     var color = vec4<f32>(model.color) / 255.0;
-    color[3] = color[3] * bundle_opacity;
+    color[3] = color[3] * model.bundle_opacity;
     out.color = color;
-    out.clip_position = transform.view_proj * vec4<f32>(model.position, 1.0);
+    out.clip_position = transform.view_proj * vec4<f32>(model.position.xy + model.bundle_offset, model.position.z, 1.0);
 
     return out;
 }

--- a/galileo/src/render/wgpu/pipelines/shaders/image.wgsl
+++ b/galileo/src/render/wgpu/pipelines/shaders/image.wgsl
@@ -16,7 +16,7 @@ struct VertexInput {
     @location(2) tex_coord: vec2<f32>,
     @location(3) offset: vec2<f32>,
     @location(10) bundle_opacity: f32,
-    @location(11) bundle_offset: vec2<f32>,
+    @location(11) bundle_offset: vec3<f32>,
 }
 
 struct VertexOutput {
@@ -32,7 +32,7 @@ fn vs_main(
     var out: VertexOutput;
     out.tex_coord = model.tex_coord;
 
-    var point_position = transform.view_proj * vec4<f32>(model.position + model.bundle_offset, 0.0, 1.0);
+    var point_position = transform.view_proj * vec4<f32>(model.position + model.bundle_offset.xy, model.bundle_offset.z, 1.0);
     var vertex_delta = vec4<f32>(model.offset * transform.inv_screen_size * point_position[3] * 2.0, 0.0, 0.0);
 
     out.clip_position = point_position + vertex_delta;

--- a/galileo/src/render/wgpu/pipelines/shaders/image.wgsl
+++ b/galileo/src/render/wgpu/pipelines/shaders/image.wgsl
@@ -16,6 +16,7 @@ struct VertexInput {
     @location(2) tex_coord: vec2<f32>,
     @location(3) offset: vec2<f32>,
     @location(10) bundle_opacity: f32,
+    @location(11) bundle_offset: vec2<f32>,
 }
 
 struct VertexOutput {
@@ -31,7 +32,7 @@ fn vs_main(
     var out: VertexOutput;
     out.tex_coord = model.tex_coord;
 
-    var point_position = transform.view_proj * vec4<f32>(model.position, 0.0, 1.0);
+    var point_position = transform.view_proj * vec4<f32>(model.position + model.bundle_offset, 0.0, 1.0);
     var vertex_delta = vec4<f32>(model.offset * transform.inv_screen_size * point_position[3] * 2.0, 0.0, 0.0);
 
     out.clip_position = point_position + vertex_delta;

--- a/galileo/src/render/wgpu/pipelines/shaders/map_ref.wgsl
+++ b/galileo/src/render/wgpu/pipelines/shaders/map_ref.wgsl
@@ -15,6 +15,8 @@ struct VertexInput {
     @location(1) color: vec4<f32>,
     @location(2) norm: vec2<f32>,
     @location(3) norm_limit: f32,
+    @location(10) bundle_opacity: f32,
+    @location(11) bundle_offset: vec2<f32>,
 }
 
 struct VertexOutput {
@@ -25,11 +27,10 @@ struct VertexOutput {
 @vertex
 fn vs_main(
     model: VertexInput,
-    @location(10) bundle_opacity: f32,
 ) -> VertexOutput {
     var out: VertexOutput;
     var color = model.color;
-    color[3] = model.color[3] * bundle_opacity;
+    color[3] = model.color[3] * model.bundle_opacity;
     out.color = color;
 
     var norm_length = sqrt(model.norm[0] * model.norm[0] + model.norm[1] * model.norm[1]) * transform.resolution;
@@ -40,7 +41,7 @@ fn vs_main(
     }
 
     let norm = model.norm * norm_limit * transform.resolution;
-    let vertex_position = transform.view_proj * vec4<f32>(model.position.xy + norm, model.position[2], 1.0);
+    let vertex_position = transform.view_proj * vec4<f32>(model.position.xy + model.bundle_offset + norm, model.position[2], 1.0);
 
     out.clip_position = vertex_position;
 

--- a/galileo/src/render/wgpu/pipelines/shaders/map_ref.wgsl
+++ b/galileo/src/render/wgpu/pipelines/shaders/map_ref.wgsl
@@ -16,7 +16,7 @@ struct VertexInput {
     @location(2) norm: vec2<f32>,
     @location(3) norm_limit: f32,
     @location(10) bundle_opacity: f32,
-    @location(11) bundle_offset: vec2<f32>,
+    @location(11) bundle_offset: vec3<f32>,
 }
 
 struct VertexOutput {
@@ -41,7 +41,8 @@ fn vs_main(
     }
 
     let norm = model.norm * norm_limit * transform.resolution;
-    let vertex_position = transform.view_proj * vec4<f32>(model.position.xy + model.bundle_offset + norm, model.position[2], 1.0);
+    let position = model.position + model.bundle_offset;
+    let vertex_position = transform.view_proj * vec4<f32>(position.xy + norm, model.position.z, 1.0);
 
     out.clip_position = vertex_position;
 

--- a/galileo/src/render/wgpu/pipelines/shaders/screen_set.wgsl
+++ b/galileo/src/render/wgpu/pipelines/shaders/screen_set.wgsl
@@ -16,8 +16,8 @@ struct VertexInput {
 }
 
 struct SetInput {
-    @location(10) anchor: vec3<f32>,
-    @location(11) opacity: f32,
+    @location(10) opacity: f32,
+    @location(11) anchor: vec3<f32>,
 }
 
 struct VertexOutput {

--- a/galileo/src/render/wgpu/pipelines/shaders/screen_set_image.wgsl
+++ b/galileo/src/render/wgpu/pipelines/shaders/screen_set_image.wgsl
@@ -16,8 +16,8 @@ struct VertexInput {
 }
 
 struct SetInput {
-    @location(10) anchor: vec3<f32>,
-    @location(11) opacity: f32,
+    @location(10) opacity: f32,
+    @location(11) anchor: vec3<f32>,
 }
 
 struct VertexOutput {


### PR DESCRIPTION
This PR makes raster and vector tile layers reuse loaded and tessellated tiles when wrapping around the earth. It allows setting offset for a whole render bundle that is applied to all vertices in the bundle.

This also lays ground work to deal with #179, as it is possible now to tessellate polygons and lines closer to [0,0], and then apply offset to them without changing coordinates of all the vertices.

Fixes #223 