### PR TITLE
fix: Use aligned buffer when copying buffers from texture

### DIFF
--- a/galileo/examples/render_to_file.rs
+++ b/galileo/examples/render_to_file.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
         .expect("cannot project extent");
     let center = extent.center();
 
-    let image_size = Size::new(512, 512);
+    let image_size = Size::new(400, 400);
 
     let width_resolution = extent.width() / image_size.width() as f64;
     let height_resolution = extent.height() / image_size.height() as f64;

--- a/galileo/src/layer/feature_layer/bundle_store.rs
+++ b/galileo/src/layer/feature_layer/bundle_store.rs
@@ -76,7 +76,7 @@ impl BundleStore {
         self.required_update.updated();
     }
 
-    pub(super) fn packed(&self) -> Vec<BundleToDraw> {
+    pub(super) fn packed(&self) -> Vec<BundleToDraw<'_>> {
         self.packed
             .values()
             .map(|v| BundleToDraw::with_opacity(&**v, 1.0))


### PR DESCRIPTION
When an image we are trying to get from the renderer does not have width divisible by 64 the operation failed because WGPU requires buffer width to be aligned to 256 bytes. So we need to align the buffer size and copy bytes to a pixel buffer of requested size later.