### PR TITLE
bugfix: Fix zoom on mobile

### DIFF
--- a/galileo-egui/src/egui_map.rs
+++ b/galileo-egui/src/egui_map.rs
@@ -319,8 +319,17 @@ impl<'a> EguiMapState {
 
                 Some(RawUserEvent::Scroll(zoom))
             }
-            Event::Touch { device_id: _, id, phase, pos, force: _ } => {
-                let event = TouchEvent { touch_id: id.0, position: Point2::new(pos.x as f64, pos.y as f64) };
+            Event::Touch {
+                device_id: _,
+                id,
+                phase,
+                pos,
+                force: _,
+            } => {
+                let event = TouchEvent {
+                    touch_id: id.0,
+                    position: Point2::new(pos.x as f64, pos.y as f64),
+                };
                 match phase {
                     egui::TouchPhase::Start => Some(RawUserEvent::TouchStart(event)),
                     egui::TouchPhase::Move => Some(RawUserEvent::TouchMove(event)),


### PR DESCRIPTION
This commit adds passing through the touch events to the event_processor which allows pinch zoom to work on touch devices. There seems to be some oddities on iOS when trying to zoom after have interacted with an egui element but I do not have the tools to debug.

Closes #272 