### PR TITLE
core: update to egui `0.33`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ cfg-if = "1"
 console_log = "1"
 console_error_panic_hook = "0.1"
 csv = "1.3"
-egui = "0.32"
-egui-wgpu = "0.32"
-eframe = { version = "0.32", default-features = false }
+egui = "0.33"
+egui-wgpu = "0.33"
+eframe = { version = "0.33", default-features = false }
 env_logger = "0.11"
 fontdb = { version = "0.23", default-features = false }
 font-kit = "0.14"
@@ -96,5 +96,5 @@ wasm-bindgen-derive = "0.2"
 wasm-bindgen-futures = "0.4"
 web-time = "1"
 web-sys = "0.3"
-wgpu = { version = "25", default-features = false, features = ["metal", "wgsl", "webgl", "vulkan", "gles"] }
+wgpu = { version = "27.0.1", default-features = false, features = ["metal", "wgsl", "webgl", "vulkan", "gles"] }
 winit = { version = "0.30", default-features = false }

--- a/galileo/src/render/wgpu/mod.rs
+++ b/galileo/src/render/wgpu/mod.rs
@@ -396,6 +396,7 @@ impl WgpuRenderer {
                 label: None,
                 memory_hints: Default::default(),
                 trace: wgpu::Trace::Off,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
             })
             .await
             .expect("Failed to obtain WGPU device")
@@ -598,7 +599,10 @@ impl WgpuRenderer {
             }
         });
 
-        if let Err(err) = self.device.poll(wgpu::PollType::Wait) {
+        if let Err(err) = self.device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: Some(std::time::Duration::from_secs(60)),
+        }) {
             log::error!("polling device failed: {err:?}");
         }
 
@@ -652,6 +656,7 @@ impl WgpuRenderer {
                     label: Some("Render Pass"),
                     color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                         view: &renderer_targets.multisampling_view,
+                        depth_slice: None,
                         resolve_target: Some(view),
                         ops: wgpu::Operations {
                             load: wgpu::LoadOp::Clear(wgpu::Color {
@@ -762,6 +767,7 @@ impl WgpuRenderer {
                 label: Some("Horizon Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: texture_view,
+                    depth_slice: None,
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Load,
@@ -921,6 +927,7 @@ impl Canvas for WgpuCanvas<'_> {
                 label: Some("Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view,
+                    depth_slice: None,
                     resolve_target,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Load,
@@ -1121,6 +1128,7 @@ impl Canvas for WgpuCanvas<'_> {
                 label: Some("Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view,
+                    depth_slice: None,
                     resolve_target,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Load,


### PR DESCRIPTION
Notes about `wgpu` `v27.0.1`:                                                                                                                                                                     
- Same version as `egui` `v0.33` is using ([source](https://github.com/emilk/egui/blob/0.33.3/Cargo.toml#L143))       
- Latest `wgpu` introduces some new fields on different structs `galileo` is using ([CHANGELOG](https://github.com/gfx-rs/wgpu/blob/trunk/CHANGELOG.md)). This PR sets `default`  values for them. Pls double check.
   