### PR TITLE
 Added support for cubic interpolation

### DIFF
--- a/galileo/Cargo.toml
+++ b/galileo/Cargo.toml
@@ -30,7 +30,6 @@ base64 = { workspace = true }
 bytemuck = { workspace = true, features = ["derive"] }
 bytes = { workspace = true }
 cfg-if = { workspace = true }
-cubic-bezier = "1.0.0"
 futures-intrusive = { workspace = true }
 galileo-mvt = { workspace = true }
 galileo-types = { workspace = true }

--- a/galileo/src/layer/vector_tile_layer/expressions.rs
+++ b/galileo/src/layer/vector_tile_layer/expressions.rs
@@ -79,6 +79,22 @@ pub struct CubicInterpolationArgs<T> {
     step_values: BTreeSet<StepValue<T>>,
 }
 
+impl<T: Copy> CubicInterpolationArgs<T> {
+    /// Returns a new instance of `CubicInterpolationArgs`
+    pub fn new(
+        control_points: [f64; 4],
+        step_values: IntoIter<StepValue<T>>,
+    ) -> Result<Self, String> {
+        if step_values.len() < 2 {
+            return Err("At least 2 step values required".to_string());
+        }
+        Ok(Self {
+            control_points,
+            step_values: step_values.into_iter().collect::<BTreeSet<_>>(),
+        })
+    }
+}
+
 /// Wrapper type for each step value
 /// i.e. resolution and a Color or a Number
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
@@ -343,6 +359,13 @@ fn inv_bezier(x0: f64, cpts: [f64; 4]) -> f64 {
     bisection_solve(f, 0., 1., 0.001)
 }
 
+///  Cubic bezier interpolation solver.
+///
+/// The math formula for algorithm is:
+///   - `Bx(t) = 3(1-t)²t·x1 + 3(1-t)t²·x2 + t³`
+///   - `By(t) = 3(1-t)²t·y1 + 3(1-t)t²·y2 + t³`
+///     Implementation is taken from: https://en.wikipedia.org/wiki/B%C3%A9zier_curve
+///
 fn cubic_interpolation(
     x_start: f64,
     x_end: f64,
@@ -353,6 +376,7 @@ fn cubic_interpolation(
 ) -> f64 {
     let x_normalized =
         ((x0 - x_start) / (x_end - x_start).clamp(f64::EPSILON, f64::MAX)).clamp(0., 1.);
+    // inverse of Bx(t) for x_normalized
     let t = inv_bezier(x_normalized, control_points);
     let y1 = control_points[1];
     let y2 = control_points[3];
@@ -630,6 +654,278 @@ mod number_tests {
 
         assert_eq!(expr.evaluate(25.0).round(), 41.0);
         assert_eq!(expr.evaluate(60.0).round(), 132.0);
+    }
+
+    #[test]
+    fn cubic_interpolation_bounds() {
+        let args: CubicInterpolationArgs<Color> = CubicInterpolationArgs::new(
+            [0.0, 1.0, 0.5, 0.75],
+            vec![
+                StepValue {
+                    resolution: 50.0,
+                    step_value: Color::rgba(128, 128, 128, 128),
+                },
+                StepValue {
+                    resolution: 75.0,
+                    step_value: Color::rgba(200, 200, 200, 200),
+                },
+            ]
+            .into_iter(),
+        )
+        .expect("failed to create interpolation arguments");
+
+        let expr = InterpolateExpression::new(InterpolationArgs::Cubic(args));
+
+        assert_eq!(expr.evaluate(0.0), Color::rgba(128, 128, 128, 128));
+        assert_eq!(expr.evaluate(100.0), Color::rgba(200, 200, 200, 200));
+    }
+
+    #[test]
+    fn cubic_interpolation_bounds_f64() {
+        let args: CubicInterpolationArgs<Color> = CubicInterpolationArgs::new(
+            [0.0, 1.0, 0.5, 0.75],
+            vec![
+                StepValue {
+                    resolution: 50.0,
+                    step_value: Color::rgba(128, 128, 128, 128),
+                },
+                StepValue {
+                    resolution: 75.0,
+                    step_value: Color::rgba(200, 200, 200, 200),
+                },
+            ]
+            .into_iter(),
+        )
+        .expect("failed to create interpolation arguments");
+
+        let expr = InterpolateExpression::new(InterpolationArgs::Cubic(args));
+
+        assert_eq!(expr.evaluate(0.0), Color::rgba(128, 128, 128, 128));
+        assert_eq!(expr.evaluate(100.0), Color::rgba(200, 200, 200, 200));
+    }
+
+    #[test]
+    fn cubic_interpolation() {
+        let args: CubicInterpolationArgs<Color> = CubicInterpolationArgs::new(
+            [0.0, 1.0, 0.5, 0.75],
+            vec![
+                StepValue {
+                    resolution: 0.0,
+                    step_value: Color::rgba(0, 0, 0, 0),
+                },
+                StepValue {
+                    resolution: 50.0,
+                    step_value: Color::rgba(128, 128, 128, 128),
+                },
+                StepValue {
+                    resolution: 75.0,
+                    step_value: Color::rgba(200, 200, 200, 200),
+                },
+            ]
+            .into_iter(),
+        )
+        .expect("failed to create interpolation arguments");
+
+        let expr = InterpolateExpression::new(InterpolationArgs::Cubic(args));
+
+        assert_eq!(expr.evaluate(25.0), Color::rgba(108, 108, 108, 108));
+        assert_eq!(expr.evaluate(60.0), Color::rgba(186, 186, 186, 186));
+    }
+
+    #[test]
+    fn cubic_interpolation_f64() {
+        let args: CubicInterpolationArgs<f64> = CubicInterpolationArgs::new(
+            [0.0, 0.25, 0.5, 0.75],
+            vec![
+                StepValue {
+                    resolution: 0.0,
+                    step_value: 0.0,
+                },
+                StepValue {
+                    resolution: 50.0,
+                    step_value: 100.0,
+                },
+                StepValue {
+                    resolution: 75.0,
+                    step_value: 200.0,
+                },
+            ]
+            .into_iter(),
+        )
+        .expect("failed to create interpolation arguments");
+
+        let expr = InterpolateExpression::new(InterpolationArgs::Cubic(args));
+
+        assert_eq!(expr.evaluate(25.0).round(), 67.0);
+        assert_eq!(expr.evaluate(60.0).round(), 158.0);
+    }
+
+    #[test]
+    fn cubic_interpolation_unordered() {
+        let args: CubicInterpolationArgs<Color> = CubicInterpolationArgs::new(
+            [0.0, 1.0, 0.5, 0.75],
+            vec![
+                StepValue {
+                    resolution: 50.0,
+                    step_value: Color::rgba(128, 128, 128, 128),
+                },
+                StepValue {
+                    resolution: 0.0,
+                    step_value: Color::rgba(0, 0, 0, 0),
+                },
+                StepValue {
+                    resolution: 75.0,
+                    step_value: Color::rgba(200, 200, 200, 200),
+                },
+            ]
+            .into_iter(),
+        )
+        .expect("failed to create interpolation arguments");
+
+        let expr = InterpolateExpression::new(InterpolationArgs::Cubic(args));
+
+        assert_eq!(expr.evaluate(25.0), Color::rgba(108, 108, 108, 108));
+        assert_eq!(expr.evaluate(60.0), Color::rgba(186, 186, 186, 186));
+    }
+
+    #[test]
+    fn cubic_interpolation_unordered_f64() {
+        let args: CubicInterpolationArgs<f64> = CubicInterpolationArgs::new(
+            [0.0, 0.25, 0.5, 0.75],
+            vec![
+                StepValue {
+                    resolution: 50.0,
+                    step_value: 100.0,
+                },
+                StepValue {
+                    resolution: 0.0,
+                    step_value: 0.0,
+                },
+                StepValue {
+                    resolution: 75.0,
+                    step_value: 200.0,
+                },
+            ]
+            .into_iter(),
+        )
+        .expect("failed to create interpolation arguments");
+
+        let expr = InterpolateExpression::new(InterpolationArgs::Cubic(args));
+
+        assert_eq!(expr.evaluate(25.0).round(), 67.0);
+        assert_eq!(expr.evaluate(60.0).round(), 158.0);
+    }
+
+    #[test]
+    fn cubic_interpolation_symmetric_control_points() {
+        let args: CubicInterpolationArgs<Color> = CubicInterpolationArgs::new(
+            [0.0, 1.0, 0.0, 1.0],
+            vec![
+                StepValue {
+                    resolution: 0.0,
+                    step_value: Color::rgba(0, 0, 0, 0),
+                },
+                StepValue {
+                    resolution: 50.0,
+                    step_value: Color::rgba(128, 128, 128, 128),
+                },
+                StepValue {
+                    resolution: 75.0,
+                    step_value: Color::rgba(200, 200, 200, 200),
+                },
+            ]
+            .into_iter(),
+        )
+        .expect("failed to create interpolation arguments");
+
+        let expr = InterpolateExpression::new(InterpolationArgs::Cubic(args));
+
+        assert_eq!(expr.evaluate(25.0), Color::rgba(126, 126, 126, 126));
+        assert_eq!(expr.evaluate(60.0), Color::rgba(198, 198, 198, 198));
+    }
+
+    #[test]
+    fn cubic_interpolation_symmetric_control_points_f64() {
+        let args: CubicInterpolationArgs<f64> = CubicInterpolationArgs::new(
+            [0.0, 1.0, 0.0, 1.0],
+            vec![
+                StepValue {
+                    resolution: 0.0,
+                    step_value: 0.0,
+                },
+                StepValue {
+                    resolution: 50.0,
+                    step_value: 100.0,
+                },
+                StepValue {
+                    resolution: 75.0,
+                    step_value: 200.0,
+                },
+            ]
+            .into_iter(),
+        )
+        .expect("failed to create interpolation arguments");
+
+        let expr = InterpolateExpression::new(InterpolationArgs::Cubic(args));
+
+        assert_eq!(expr.evaluate(25.0).round(), 99.0);
+        assert_eq!(expr.evaluate(60.0).round(), 198.0);
+    }
+
+    #[test]
+    fn cubic_interpolation_zeroes_control_points() {
+        let args: CubicInterpolationArgs<f64> = CubicInterpolationArgs::new(
+            [0.0, 0.0, 0.0, 0.0],
+            vec![
+                StepValue {
+                    resolution: 0.0,
+                    step_value: 0.0,
+                },
+                StepValue {
+                    resolution: 50.0,
+                    step_value: 100.0,
+                },
+                StepValue {
+                    resolution: 75.0,
+                    step_value: 200.0,
+                },
+            ]
+            .into_iter(),
+        )
+        .expect("failed to create interpolation arguments");
+
+        let expr = InterpolateExpression::new(InterpolationArgs::Cubic(args));
+
+        assert_eq!(expr.evaluate(25.0).round(), 50.0);
+        assert_eq!(expr.evaluate(60.0).round(), 140.0);
+    }
+
+    #[test]
+    fn cubic_interpolation_equal_control_points() {
+        let args: CubicInterpolationArgs<f64> = CubicInterpolationArgs::new(
+            [0.3, 0.3, 0.3, 0.3],
+            vec![
+                StepValue {
+                    resolution: 0.0,
+                    step_value: 0.0,
+                },
+                StepValue {
+                    resolution: 50.0,
+                    step_value: 100.0,
+                },
+                StepValue {
+                    resolution: 75.0,
+                    step_value: 200.0,
+                },
+            ]
+            .into_iter(),
+        )
+        .expect("failed to create interpolation arguments");
+
+        let expr = InterpolateExpression::new(InterpolationArgs::Cubic(args));
+
+        assert_eq!(expr.evaluate(25.0).round(), 50.0);
+        assert_eq!(expr.evaluate(60.0).round(), 140.0);
     }
 
     #[test]


### PR DESCRIPTION
Solves issue: #300
I've assumed that if the equation doesn't solve, it panics, If we need to assume not so, then the evaluation
becomes fallible that deviates slightly from MapBox Specs, I remember you saying`evaluate()` can be return `Option<T>`. 
If so, I will refactor the exisiting code to  support `Option<T>`. 

Also, from the last changes, I'd apparently clamped the all interpolated results to 0 - 255, to which I've fixed the range as well.