### PR TITLE
fix: Reverts storing tiles at actual positions for correct rendering

### DIFF
--- a/galileo/src/layer/raster_tile_layer/mod.rs
+++ b/galileo/src/layer/raster_tile_layer/mod.rs
@@ -3,7 +3,6 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use galileo_types::cartesian::Vector2;
 use provider::RasterTileProvider;
 use web_time::Duration;
 
@@ -161,12 +160,7 @@ impl Layer for RasterTileLayer {
         let displayed_tiles = self.tile_container.tiles.lock();
         let to_render: Vec<_> = displayed_tiles
             .values()
-            .filter_map(|v| {
-                let tile_bbox = self.tile_schema.tile_bbox(v.index)?;
-                let offset = Vector2::new(tile_bbox.x_min() as f32, tile_bbox.y_max() as f32);
-
-                Some(BundleToDraw::new(&*v.bundle, v.opacity, offset))
-            })
+            .map(|v| BundleToDraw::with_opacity(&*v.bundle, v.opacity))
             .collect();
 
         canvas.draw_bundles(&to_render, RenderOptions::default());

--- a/galileo/src/layer/raster_tile_layer/provider.rs
+++ b/galileo/src/layer/raster_tile_layer/provider.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use galileo_types::cartesian::Rect;
 use maybe_sync::{MaybeSend, MaybeSync};
 use parking_lot::Mutex;
 use quick_cache::sync::Cache;
@@ -168,12 +167,10 @@ impl RasterTileProvider {
         let tiles = self.tiles.lock();
         for index in indices {
             if let Some(TileState::Loaded(image)) = tiles.get(index) {
-                let Some(resolution) = self.tile_schema.lod_resolution(index.z) else {
+                let Some(tile_bbox) = self.tile_schema.tile_bbox(index.into_wrapping()) else {
+                    log::warn!("Failed to get bbox for tile {index:?}");
                     continue;
                 };
-                let width = self.tile_schema.tile_width() as f64;
-                let height = self.tile_schema.tile_height() as f64;
-                let tile_bbox = Rect::new(0.0, 0.0, width * resolution, -height * resolution);
 
                 let mut bundle = RenderBundle::default();
                 bundle.add_image(


### PR DESCRIPTION
# Problem
White lines (gaps) appeared between tiles at certain zoom levels, visible both horizontally and vertically. See #281.

# Root Cause
Commit 3678449 ("perf: Do not duplicate same vector tiles in GPU memory") introduced an optimization that:
1. Stored tiles at origin `(0, 0)` instead of their actual world position
2. Applied an offset at render time to position tiles correctly

The offset was passed as `f32`, but Web Mercator coordinates can be very large (e.g., `±20037508`). At these magnitudes, `f32` loses precision (only ~7 significant digits), causing tiles to be positioned incorrectly by small amounts - resulting in visible gaps.

# The Fix
Reverted to storing tiles at their actual world positions (`f64` precision) in the render bundle, eliminating the need for runtime offsets.

# Notes for next steps

### What Was Removed
The deduplication optimization for wrapped tiles (tiles that appear multiple times when crossing the 180° longitude line) is no longer active for raster tiles. Each tile instance now has its own GPU buffer with absolute coordinates.

### Why Not Fix the Offset Approach (yet)?
Properly fixing the offset-based approach would require:
1. Changing `BundleToDraw::offset` from `Vector2<f32>` to `Vector2<f64>`
2. Updating `DisplayInstance::offset` in the wgpu renderer from `[f32; 3]` to `[f64; 3]`
3. Modifying WGSL shaders - but GPU shaders inherently use `f32` (while `f64` exists in some shader languages, it's not universally supported and is slower)

A proper solution would involve computing relative offsets (tile position minus view center) to keep values small enough for `f32` precision, but this requires careful coordination with the view transformation matrix which already subtracts the view center. This is a more invasive change that could be pursued in a future optimization effort.

Closes #281 

_^ All done with help of CLAUDE._