### PR TITLE
refactor: replaced use of Resolution with Zlevel

### DIFF
--- a/galileo/examples/resolution_and_zlevel_interpolation.rs
+++ b/galileo/examples/resolution_and_zlevel_interpolation.rs
@@ -146,9 +146,9 @@ fn zlevel_based_interpolation() -> StyleRule {
           "cubic":{
           "control_points": [0.25, 0.0, 0.75, 1.0],
             "step_values": [
-              {"resolution": 9783.939620501465, "step_value": "#81C4EC"},
-              {"resolution": 611.4962262813416, "step_value": "#29546dff"},
-              {"resolution": 2.3886571339114906, "step_value": "#3d835cff"}
+              {"resolution": 2, "step_value": "#81C4EC"},
+              {"resolution": 6, "step_value": "#29546dff"},
+              {"resolution": 12, "step_value": "#3d835cff"}
             ]
           }
         },

--- a/galileo/src/layer/vector_tile_layer/expressions.rs
+++ b/galileo/src/layer/vector_tile_layer/expressions.rs
@@ -258,22 +258,12 @@ impl<T> InterpolateExpression<T> {
                 }
             }
             OperationBase::Zlevel => {
-                let mut z_step_values: Vec<_> = self
+                let z_step_values: Vec<_> = self
                     .interpolation_args
                     .step_values()
                     .iter()
-                    .map(|val| {
-                        let z = tile_schema.select_lod(val.basis)?.z_index;
-                        Some(StepValue {
-                            basis: z.into(),
-                            step_value: val.step_value,
-                        })
-                    })
-                    .collect::<Option<Vec<_>>>()?;
+                    .collect::<Vec<_>>();
 
-                // zlevels are have to be reversed as resolution is
-                // inversely proportional to values
-                z_step_values.sort();
                 // generates a iterating window of 2 step values
                 // and compares the current_z_level.
 
@@ -295,6 +285,7 @@ pub(crate) enum Channel {
     B,
     A,
 }
+
 /// This trait is used to define interpolatability for a type
 /// on implementing this, `InterpolateExpression` allows for the use of evaluate method.
 trait InterpolatableValue: Copy {
@@ -450,24 +441,9 @@ impl<T: InterpolatableValue> InterpolateExpression<T> {
 
             OperationBase::Zlevel => {
                 let current_z_level = tile_schema.select_lod(current_resolution)?.z_index;
-                // transforms resolution into z_levels
-                let mut z_step_values: Vec<_> = step_values
+                step_values
                     .iter()
-                    .map(|val| {
-                        let z = tile_schema.select_lod(val.basis)?.z_index;
-                        Some(StepValue {
-                            basis: z.into(),
-                            step_value: val.step_value,
-                        })
-                    })
-                    .collect::<Option<Vec<_>>>()?;
-
-                // zlevels are have to be reversed as resolution is
-                // inversely proportional to values
-                z_step_values.sort();
-                // generates a iterating window of 2 step values
-                // and compares the current_z_level.
-                z_step_values
+                    .collect::<Vec<_>>()
                     .windows(2)
                     .find(|w| {
                         current_z_level >= w[0].basis as u32 && current_z_level <= w[1].basis as u32
@@ -1578,11 +1554,11 @@ mod zlevel_tests {
         let args: LinearInterpolationArgs<f64> = LinearInterpolationArgs::new(
             vec![
                 StepValue {
-                    basis: default_tile_schema().lod_resolution(2).unwrap(),
+                    basis: 2.0,
                     step_value: 2.0,
                 },
                 StepValue {
-                    basis: default_tile_schema().lod_resolution(10).unwrap(),
+                    basis: 10.0,
                     step_value: 10.0,
                 },
             ]
@@ -1596,7 +1572,9 @@ mod zlevel_tests {
         for i in 2..11 {
             assert_eq!(
                 expr.evaluate(
-                    default_tile_schema().lod_resolution(i).unwrap(),
+                    default_tile_schema()
+                        .lod_resolution(i)
+                        .expect("Unexpected z-level"),
                     &default_tile_schema()
                 )
                 .unwrap(),


### PR DESCRIPTION
This replaces the use of Resolution for each step with Zlevels. 
It'll probably easier to define steps with Zlevels instead of raw resolution values.