### PR TITLE
fix: Fix white lines between raster tiles on some GPUs

### DIFF
--- a/galileo/src/layer/raster_tile_layer/mod.rs
+++ b/galileo/src/layer/raster_tile_layer/mod.rs
@@ -12,7 +12,7 @@ use super::tiles::TilesContainer;
 use crate::layer::attribution::Attribution;
 use crate::messenger::Messenger;
 use crate::render::{BundleToDraw, Canvas, RenderOptions};
-use crate::tile_schema::{TileIndex, TileSchema};
+use crate::tile_schema::{TileSchema, WrappingTileIndex};
 use crate::view::MapView;
 
 mod provider;
@@ -86,12 +86,10 @@ impl RasterTileLayer {
         };
 
         let needed_indices: Vec<_> = tile_iter.collect();
-        let mut to_pack: Vec<TileIndex> = needed_indices.iter().map(|t| (*t).into()).collect();
-        to_pack.dedup();
 
         self.tile_container
             .tile_provider
-            .pack_tiles(&to_pack, canvas);
+            .pack_tiles(&needed_indices, canvas);
         let requires_redraw = self
             .tile_container
             .update_displayed_tiles(needed_indices, ());
@@ -102,7 +100,7 @@ impl RasterTileLayer {
     }
 
     async fn load_tile(
-        index: TileIndex,
+        index: WrappingTileIndex,
         tile_loader: Arc<dyn RasterTileLoader>,
         tiles: Arc<TilesContainer<(), RasterTileProvider>>,
         messenger: Option<Arc<dyn Messenger>>,
@@ -112,7 +110,7 @@ impl RasterTileLayer {
             return;
         }
 
-        let load_result = tile_loader.load(index).await;
+        let load_result = tile_loader.load(index.into()).await;
 
         match load_result {
             Ok(decoded_image) => {
@@ -135,13 +133,7 @@ impl RasterTileLayer {
             for index in iter {
                 let tile_provider = self.tile_loader.clone();
                 let messenger = self.messenger.clone();
-                Self::load_tile(
-                    index.into(),
-                    tile_provider,
-                    self.tile_container.clone(),
-                    messenger,
-                )
-                .await;
+                Self::load_tile(index, tile_provider, self.tile_container.clone(), messenger).await;
             }
         }
     }
@@ -159,12 +151,7 @@ impl Layer for RasterTileLayer {
         let displayed_tiles = self.tile_container.tiles.lock();
         let to_render: Vec<_> = displayed_tiles
             .values()
-            .filter_map(|v| {
-                let tile_bbox = self.tile_schema.tile_bbox(v.index)?;
-                let offset = Vector2::new(tile_bbox.x_min() as f32, tile_bbox.y_max() as f32);
-
-                Some(BundleToDraw::new(&*v.bundle, v.opacity, offset))
-            })
+            .map(|v| BundleToDraw::new(&*v.bundle, v.opacity, Vector2::default()))
             .collect();
 
         canvas.draw_bundles(&to_render, RenderOptions::default());
@@ -177,7 +164,7 @@ impl Layer for RasterTileLayer {
                 let container = self.tile_container.clone();
                 let messenger = self.messenger.clone();
                 crate::async_runtime::spawn(async move {
-                    Self::load_tile(index.into(), tile_provider, container, messenger).await;
+                    Self::load_tile(index, tile_provider, container, messenger).await;
                 });
             }
         }

--- a/galileo/src/layer/raster_tile_layer/provider.rs
+++ b/galileo/src/layer/raster_tile_layer/provider.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use galileo_types::cartesian::Rect;
 use maybe_sync::{MaybeSend, MaybeSync};
 use parking_lot::Mutex;
 use quick_cache::GuardResult;
@@ -15,7 +14,9 @@ use crate::layer::tiles::TileProvider;
 use crate::platform::PlatformService;
 use crate::render::render_bundle::RenderBundle;
 use crate::render::{Canvas, ImagePaint, PackedBundle};
-use crate::tile_schema::TileIndex;
+use crate::tile_schema::{TileIndex, WrappingTileIndex};
+
+const IMAGE_CACHE_SIZE: usize = 5000;
 
 /// Provider of tlies for a [`RusterTileLayer`](super::RasterTileLayer).
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -122,14 +123,15 @@ impl RasterTileLoader for RestTileLoader {
 #[derive(Clone)]
 enum TileState {
     Loading,
-    Loaded(Arc<DecodedImage>),
+    Loaded,
     Rendered(Arc<dyn PackedBundle>),
     Error,
 }
 
 #[derive(Debug)]
 pub(crate) struct RasterTileProvider {
-    tiles: Mutex<Cache<TileIndex, TileState>>,
+    tile_cache: Mutex<Cache<WrappingTileIndex, TileState>>,
+    tile_images: Mutex<Cache<TileIndex, Arc<DecodedImage>>>,
     tile_schema: TileSchema,
 }
 
@@ -137,14 +139,15 @@ impl RasterTileProvider {
     pub(crate) fn new(tile_schema: TileSchema) -> Self {
         Self {
             tile_schema,
-            tiles: Mutex::new(Cache::new(5000)),
+            tile_cache: Mutex::new(Cache::new(IMAGE_CACHE_SIZE)),
+            tile_images: Mutex::new(Cache::new(IMAGE_CACHE_SIZE)),
         }
     }
 }
 
 impl RasterTileProvider {
-    pub(crate) fn set_loading(&self, index: TileIndex) -> bool {
-        match self.tiles.lock().get_value_or_guard(&index, None) {
+    pub(crate) fn set_loading(&self, index: WrappingTileIndex) -> bool {
+        match self.tile_cache.lock().get_value_or_guard(&index, None) {
             GuardResult::Value(_) => true,
             GuardResult::Guard(guard) => guard.insert(TileState::Loading).is_err(),
             GuardResult::Timeout => {
@@ -154,26 +157,29 @@ impl RasterTileProvider {
         }
     }
 
-    pub(crate) fn set_loaded(&self, index: TileIndex, image: DecodedImage) {
-        self.tiles
+    pub(crate) fn set_loaded(&self, index: WrappingTileIndex, image: DecodedImage) {
+        self.tile_cache.lock().insert(index, TileState::Loaded);
+        self.tile_images
             .lock()
-            .insert(index, TileState::Loaded(Arc::new(image)));
+            .insert(index.into(), Arc::new(image));
     }
 
-    pub(crate) fn set_error(&self, index: TileIndex) {
-        self.tiles.lock().insert(index, TileState::Error);
+    pub(crate) fn set_error(&self, index: WrappingTileIndex) {
+        self.tile_cache.lock().insert(index, TileState::Error);
     }
 
-    pub(crate) fn pack_tiles(&self, indices: &[TileIndex], canvas: &dyn Canvas) {
-        let tiles = self.tiles.lock();
+    pub(crate) fn pack_tiles(&self, indices: &[WrappingTileIndex], canvas: &dyn Canvas) {
+        let tiles = self.tile_cache.lock();
+        let images = self.tile_images.lock();
         for index in indices {
-            if let Some(TileState::Loaded(image)) = tiles.get(index) {
-                let Some(resolution) = self.tile_schema.lod_resolution(index.z) else {
+            if let Some(TileState::Loaded) = tiles.get(index) {
+                let Some(image) = images.get(&TileIndex::from(*index)) else {
                     continue;
                 };
-                let width = self.tile_schema.tile_width() as f64;
-                let height = self.tile_schema.tile_height() as f64;
-                let tile_bbox = Rect::new(0.0, 0.0, width * resolution, -height * resolution);
+
+                let Some(tile_bbox) = self.tile_schema.tile_bbox(*index) else {
+                    continue;
+                };
 
                 let mut bundle = RenderBundle::default();
                 bundle.add_image(
@@ -189,8 +195,8 @@ impl RasterTileProvider {
 }
 
 impl TileProvider<()> for RasterTileProvider {
-    fn get_tile(&self, index: TileIndex, _style_id: ()) -> Option<Arc<dyn PackedBundle>> {
-        match self.tiles.lock().get(&index) {
+    fn get_tile(&self, index: WrappingTileIndex, _style_id: ()) -> Option<Arc<dyn PackedBundle>> {
+        match self.tile_cache.lock().get(&index) {
             Some(TileState::Rendered(bundle)) => Some(bundle),
             _ => None,
         }

--- a/galileo/src/layer/tiles.rs
+++ b/galileo/src/layer/tiles.rs
@@ -9,7 +9,7 @@ use parking_lot::Mutex;
 
 use crate::TileSchema;
 use crate::render::PackedBundle;
-use crate::tile_schema::{TileIndex, WrappingTileIndex};
+use crate::tile_schema::WrappingTileIndex;
 
 const DEFAULT_FADE_IN_DURATION: Duration = Duration::from_millis(300);
 
@@ -29,7 +29,11 @@ impl<StyleId: Copy> DisplayedTile<StyleId> {
 }
 
 pub(crate) trait TileProvider<StyleId> {
-    fn get_tile(&self, index: TileIndex, style_id: StyleId) -> Option<Arc<dyn PackedBundle>>;
+    fn get_tile(
+        &self,
+        index: WrappingTileIndex,
+        style_id: StyleId,
+    ) -> Option<Arc<dyn PackedBundle>>;
 }
 
 pub(crate) struct TilesContainer<StyleId, Provider>
@@ -92,7 +96,7 @@ where
                 needed_tiles.push(displayed.clone());
                 tile_indices.insert((index, style_id));
             } else {
-                match self.tile_provider.get_tile(index.into(), style_id) {
+                match self.tile_provider.get_tile(index, style_id) {
                     None => {
                         if let Some(bbox) = self.tile_schema.tile_bbox(index) {
                             to_substitute.push(bbox);

--- a/galileo/src/layer/vector_tile_layer/tile_provider/mod.rs
+++ b/galileo/src/layer/vector_tile_layer/tile_provider/mod.rs
@@ -12,7 +12,7 @@ use crate::layer::tiles::TileProvider;
 use crate::layer::vector_tile_layer::style::VectorTileStyle;
 use crate::messenger::Messenger;
 use crate::render::{Canvas, PackedBundle};
-use crate::tile_schema::TileIndex;
+use crate::tile_schema::{TileIndex, WrappingTileIndex};
 
 pub mod loader;
 pub mod processor;
@@ -56,8 +56,12 @@ impl Clone for VectorTileProvider {
 }
 
 impl TileProvider<VtStyleId> for VectorTileProvider {
-    fn get_tile(&self, index: TileIndex, style_id: VtStyleId) -> Option<Arc<dyn PackedBundle>> {
-        VectorTileProvider::get_tile(self, index, style_id)
+    fn get_tile(
+        &self,
+        index: WrappingTileIndex,
+        style_id: VtStyleId,
+    ) -> Option<Arc<dyn PackedBundle>> {
+        VectorTileProvider::get_tile(self, index.into(), style_id)
     }
 }
 


### PR DESCRIPTION
Modern GPUs have implement special logic to prevent white linex between adjacent textures (a problem called "texture bleeding"). The basic principal is to compare couples of vertices of two faces and if they are same, than consider two textures as having no gap between them, e.g. sew them together.

The tile rendering logic was written considering this, and works fine on most GPUs. But it turns out that some GPUs compare the vertices before the vertex shader is applied. This makes using same coordinates with offset for every tile produce these white lines.

To fix the issue, this commit changes how coordinates for tiles are calculated in the packed render. Instead of applying offset in the shader, we just store the coordinates of each tile with precalculated values in world coordinates.

This changes doesn't produce any unnecessary cloning of textures for tiles since texture deduplication logic is still applied to the tile images, and any given "physical" tile is loaded only once.

Fixes #281