### PR TITLE
feat: Maplibre style parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "galileo",
+    "galileo-maplibre",
     "galileo-mvt",
     "galileo-types",
     "galileo-egui",
@@ -84,6 +85,7 @@ rustybuzz = "0.20"
 serde = "1"
 serde-wasm-bindgen = "0.6"
 serde_bytes = "0.11"
+serde_ignored = "0.1"
 serde_json = "1"
 strfmt = "0.2"
 thiserror = "1"

--- a/galileo-maplibre/Cargo.toml
+++ b/galileo-maplibre/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "galileo-maplibre"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+documentation = "https://docs.rs/galileo-mvt"
+description = "Galileo layer based on Maplibre (Mapbox) style specification"
+readme = "./README.md"
+
+[dependencies]
+galileo = { workspace = true, default-features = true }
+log = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_ignored = { workspace = true }
+serde_json = { workspace = true }

--- a/galileo-maplibre/README.md
+++ b/galileo-maplibre/README.md
@@ -1,0 +1,3 @@
+Support for Maplibre styles for Galileo map.
+
+This crate is WIP. More information will be here later.

--- a/galileo-maplibre/data/maptiler_fmt.json
+++ b/galileo-maplibre/data/maptiler_fmt.json
@@ -1,0 +1,8390 @@
+{
+  "version": 8,
+  "id": "streets-v2",
+  "name": "Streets",
+  "sources": {
+    "maptiler_attribution": {
+      "attribution": "<a href=\"https://www.maptiler.com/copyright/\" target=\"_blank\">&copy; MapTiler</a> <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",
+      "type": "vector"
+    },
+    "maptiler_planet": {
+      "url": "https://api.maptiler.com/tiles/v3/tiles.json?key=mNLmXyaTH4gRlwJHSYWp",
+      "type": "vector"
+    }
+  },
+  "layers": [
+    {
+      "id": "Background",
+      "type": "background",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "background-color": {
+          "stops": [
+            [
+              6,
+              "hsl(47,79%,94%)"
+            ],
+            [
+              14,
+              "hsl(42,49%,93%)"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Meadow",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "globallandcover",
+      "maxzoom": 8,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(75,51%,85%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              0,
+              1
+            ],
+            [
+              8,
+              0.1
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "grass"
+      ]
+    },
+    {
+      "id": "Scrub",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "globallandcover",
+      "maxzoom": 8,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(97,51%,80%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              0,
+              1
+            ],
+            [
+              8,
+              0.1
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "scrub"
+      ]
+    },
+    {
+      "id": "Crop",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "globallandcover",
+      "maxzoom": 8,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(50,67%,86%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              0,
+              1
+            ],
+            [
+              8,
+              0.1
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "crop"
+      ]
+    },
+    {
+      "id": "Glacier",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landcover",
+      "maxzoom": 24,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(0,0%,100%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              0,
+              1
+            ],
+            [
+              10,
+              0.7
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "ice"
+      ]
+    },
+    {
+      "id": "Forest",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "globallandcover",
+      "maxzoom": 8,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(119,38%,76%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              1,
+              0.8
+            ],
+            [
+              8,
+              0
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "in",
+        "class",
+        "forest",
+        "tree"
+      ]
+    },
+    {
+      "id": "Sand",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landcover",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "hsl(52,93%,89%)",
+        "fill-opacity": 0.85
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "sand"
+      ]
+    },
+    {
+      "id": "Wood",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landcover",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(87,46%,85%)",
+        "fill-opacity": 1
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "wood"
+      ]
+    },
+    {
+      "id": "Residential",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "maxzoom": 24,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": {
+          "base": 1,
+          "stops": [
+            [
+              4,
+              "hsl(44,34%,87%)"
+            ],
+            [
+              16,
+              "hsl(54, 45%, 91%)"
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "residential",
+        "suburbs",
+        "neighbourhood"
+      ]
+    },
+    {
+      "id": "Industrial",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "maxzoom": 24,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          9,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "industrial"
+            ],
+            "hsl(40,67%,90%)",
+            "quarry",
+            "hsla(32, 47%, 87%, 0.2)",
+            "hsl(60, 31%, 87%)"
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "industrial"
+            ],
+            "hsl(49,54%,90%)",
+            "quarry",
+            "hsla(32, 47%, 87%, 0.5)",
+            "hsl(60, 31%, 87%)"
+          ]
+        ],
+        "fill-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          1,
+          9,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "quarry",
+            0,
+            1
+          ],
+          10,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "industrial",
+        "quarry"
+      ]
+    },
+    {
+      "id": "Grass",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landcover",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "hsl(103, 40%, 85%)",
+        "fill-opacity": 0.5
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "grass"
+      ]
+    },
+    {
+      "id": "Airport zone",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(0,0%,93%)",
+        "fill-opacity": 1
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "$type",
+        "Polygon"
+      ]
+    },
+    {
+      "id": "Pedestrian",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(43,100%,99%)",
+        "fill-opacity": 0.7
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ],
+        [
+          "!in",
+          "class",
+          "bridge",
+          "pier"
+        ],
+        [
+          "in",
+          "subclass",
+          "pedestrian",
+          "platform"
+        ]
+      ]
+    },
+    {
+      "id": "Cemetery",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "minzoom": 9,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(0,0%,88%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              9,
+              0.25
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "cemetery"
+      ]
+    },
+    {
+      "id": "Hospital",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "minzoom": 9,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(12,63%,94%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              9,
+              0.25
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "hospital"
+      ]
+    },
+    {
+      "id": "Stadium",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "minzoom": 9,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(94, 100%, 88%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              9,
+              0.25
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "pitch",
+        "stadium",
+        "playground"
+      ]
+    },
+    {
+      "id": "School",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "minzoom": 9,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(194,52%,94%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              9,
+              0.25
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "college",
+        "school",
+        "university"
+      ]
+    },
+    {
+      "id": "River tunnel",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "waterway",
+      "minzoom": 14,
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(210,73%,78%)",
+        "line-dasharray": [
+          2,
+          4
+        ],
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "brunnel",
+        "tunnel"
+      ]
+    },
+    {
+      "id": "River",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "waterway",
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(210,73%,78%)",
+        "line-width": {
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "!=",
+        "brunnel",
+        "tunnel"
+      ]
+    },
+    {
+      "id": "Water intermittent",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "water",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(205,91%,83%)",
+        "fill-opacity": 0.85
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "intermittent",
+        1
+      ]
+    },
+    {
+      "id": "Water",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "water",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(204,92%,75%)",
+        "fill-opacity": [
+          "match",
+          [
+            "get",
+            "intermittent"
+          ],
+          1,
+          0.85,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "!=",
+        "intermittent",
+        1
+      ]
+    },
+    {
+      "id": "Aeroway",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,100%)",
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          11,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "runway"
+            ],
+            3,
+            0.5
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "runway"
+            ],
+            16,
+            6
+          ]
+        ]
+      },
+      "metadata": {}
+    },
+    {
+      "id": "Heliport",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(0,0%,100%)",
+        "fill-opacity": 1
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "helipad",
+        "heliport"
+      ]
+    },
+    {
+      "id": "Ferry line",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              10,
+              "hsl(205,61%,63%)"
+            ],
+            [
+              16,
+              "hsl(205,67%,47%)"
+            ]
+          ]
+        },
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-opacity": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0.5,
+          7,
+          0.8,
+          8,
+          1
+        ],
+        "line-width": {
+          "stops": [
+            [
+              10,
+              0.5
+            ],
+            [
+              14,
+              1.1
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "ferry"
+      ]
+    },
+    {
+      "id": "Tunnel outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          "hsl(28,72%,69%)",
+          [
+            "trunk",
+            "primary"
+          ],
+          "hsl(28,72%,69%)",
+          "hsl(36,5%,80%)"
+        ],
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0,
+          7,
+          0.5,
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              0,
+              2.5
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            2,
+            0
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              2,
+              6
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            3,
+            [
+              "secondary",
+              "tertiary"
+            ],
+            2,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            1,
+            0.5
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              5,
+              8
+            ],
+            [
+              "trunk"
+            ],
+            4,
+            [
+              "primary"
+            ],
+            6,
+            [
+              "secondary"
+            ],
+            6,
+            [
+              "tertiary"
+            ],
+            4,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            3,
+            3
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway",
+              "trunk",
+              "primary"
+            ],
+            10,
+            [
+              "secondary"
+            ],
+            8,
+            [
+              "tertiary"
+            ],
+            8,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            4,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway",
+              "trunk",
+              "primary"
+            ],
+            26,
+            [
+              "secondary"
+            ],
+            26,
+            [
+              "tertiary"
+            ],
+            26,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            18,
+            18
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "!in",
+          "class",
+          "bridge",
+          "ferry",
+          "rail",
+          "transit",
+          "pier",
+          "path",
+          "aerialway",
+          "motorway_construction",
+          "trunk_construction",
+          "primary_construction",
+          "secondary_construction",
+          "tertiary_construction",
+          "minor_construction",
+          "service_construction",
+          "track_construction"
+        ]
+      ]
+    },
+    {
+      "id": "Tunnel",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          "hsl(35,100%,76%)",
+          [
+            "trunk",
+            "primary"
+          ],
+          "hsl(48,100%,88%)",
+          "hsl(0,0%,96%)"
+        ],
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          0,
+          6,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "brunnel"
+              ],
+              [
+                "bridge"
+              ],
+              0,
+              1
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            0,
+            0
+          ],
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              0,
+              2.5
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            1.5,
+            1
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              1,
+              4
+            ],
+            [
+              "trunk"
+            ],
+            2.5,
+            [
+              "primary"
+            ],
+            2.5,
+            [
+              "secondary",
+              "tertiary"
+            ],
+            1.5,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            1,
+            1
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              5,
+              6
+            ],
+            [
+              "trunk"
+            ],
+            3,
+            [
+              "primary"
+            ],
+            5,
+            [
+              "secondary"
+            ],
+            4,
+            [
+              "tertiary"
+            ],
+            3,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            2,
+            2
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway",
+              "trunk",
+              "primary"
+            ],
+            8,
+            [
+              "secondary"
+            ],
+            7,
+            [
+              "tertiary"
+            ],
+            6,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            4,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway",
+              "trunk",
+              "primary"
+            ],
+            24,
+            [
+              "secondary"
+            ],
+            24,
+            [
+              "tertiary"
+            ],
+            24,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            16,
+            16
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "!in",
+          "class",
+          "ferry",
+          "rail",
+          "transit",
+          "pier",
+          "bridge",
+          "path",
+          "aerialway",
+          "motorway_construction",
+          "trunk_construction",
+          "primary_construction",
+          "secondary_construction",
+          "tertiary_construction",
+          "minor_construction",
+          "service_construction",
+          "track_construction"
+        ]
+      ]
+    },
+    {
+      "id": "Railway tunnel",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,73%)",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ]
+    },
+    {
+      "id": "Railway tunnel hatching",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,73%)",
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ]
+    },
+    {
+      "id": "Footway tunnel outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "miter",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,100%)",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              0
+            ],
+            [
+              16,
+              0
+            ],
+            [
+              18,
+              4
+            ],
+            [
+              22,
+              8
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "path",
+          "pedestrian"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ]
+    },
+    {
+      "id": "Footway tunnel",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,63%)",
+        "line-dasharray": {
+          "stops": [
+            [
+              14,
+              [
+                1,
+                0.5
+              ]
+            ],
+            [
+              18,
+              [
+                1,
+                0.25
+              ]
+            ]
+          ]
+        },
+        "line-opacity": 0.4,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              2
+            ],
+            [
+              22,
+              5
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "path",
+          "pedestrian"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ]
+    },
+    {
+      "id": "Pier",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(42,49%,93%)"
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "pier"
+        ]
+      ]
+    },
+    {
+      "id": "Pier road",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(42,49%,93%)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1
+            ],
+            [
+              17,
+              4
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "class",
+          "pier"
+        ]
+      ]
+    },
+    {
+      "id": "Bridge outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "maxzoom": 17,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(43, 50%, 93%)",
+        "line-opacity": 0.5,
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          13,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            5,
+            8
+          ],
+          15,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            15,
+            22
+          ],
+          17,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            20,
+            24
+          ]
+        ]
+      },
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "motorway",
+          "primary",
+          "trunk"
+        ]
+      ]
+    },
+    {
+      "id": "Bridge",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(42,49%,93%)",
+        "fill-opacity": 0.6
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ]
+    },
+    {
+      "id": "Minor road outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(36,5%,80%)",
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0,
+          7,
+          0.5,
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary",
+              "tertiary"
+            ],
+            2,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            1,
+            0.5
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            6,
+            [
+              "tertiary"
+            ],
+            4,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            3,
+            3
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            8,
+            [
+              "tertiary"
+            ],
+            8,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            4,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            26,
+            [
+              "tertiary"
+            ],
+            26,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            18,
+            18
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "!in",
+          "class",
+          "aerialway",
+          "bridge",
+          "ferry",
+          "minor_construction",
+          "motorway",
+          "motorway_construction",
+          "path",
+          "path_construction",
+          "pier",
+          "primary",
+          "primary_construction",
+          "rail",
+          "secondary_construction",
+          "service_construction",
+          "tertiary_construction",
+          "track_construction",
+          "transit",
+          "trunk_construction"
+        ]
+      ]
+    },
+    {
+      "id": "Major road outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(28,72%,69%)",
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0,
+          7,
+          0.5,
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            2.4,
+            0
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            3,
+            0.5
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk"
+            ],
+            4,
+            [
+              "primary"
+            ],
+            6,
+            3
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            10,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            26,
+            18
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
+      ]
+    },
+    {
+      "id": "Highway outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(28,72%,69%)",
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0,
+          7,
+          0.5,
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              0,
+              2.5
+            ],
+            0
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              2,
+              6
+            ],
+            0.5
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              5,
+              8
+            ],
+            3
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            10,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            26,
+            18
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
+      ]
+    },
+    {
+      "id": "Road under construction",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "square",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway_construction",
+          "hsl(35,100%,76%)",
+          [
+            "trunk_construction",
+            "primary_construction"
+          ],
+          "hsl(48,100%,83%)",
+          "hsl(0,0%,100%)"
+        ],
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-opacity": [
+          "case",
+          [
+            "==",
+            [
+              "get",
+              "brunnel"
+            ],
+            "tunnel"
+          ],
+          0.7,
+          1
+        ],
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "brunnel"
+              ],
+              [
+                "bridge"
+              ],
+              0,
+              0.5
+            ],
+            [
+              "trunk_construction",
+              "primary_construction"
+            ],
+            0,
+            0
+          ],
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              0,
+              2.5
+            ],
+            [
+              "trunk_construction",
+              "primary_construction"
+            ],
+            1.5,
+            1
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              1,
+              4
+            ],
+            [
+              "trunk_construction"
+            ],
+            2.5,
+            [
+              "primary_construction"
+            ],
+            2.5,
+            [
+              "secondary_construction",
+              "tertiary_construction"
+            ],
+            1.5,
+            [
+              "minor_construction",
+              "service_construction",
+              "track_construction"
+            ],
+            1,
+            1
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              5,
+              6
+            ],
+            [
+              "trunk_construction"
+            ],
+            3,
+            [
+              "primary_construction"
+            ],
+            5,
+            [
+              "secondary_construction"
+            ],
+            4,
+            [
+              "tertiary_construction"
+            ],
+            3,
+            [
+              "minor_construction",
+              "service_construction",
+              "track_construction"
+            ],
+            2,
+            2
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction",
+              "trunk_construction",
+              "primary_construction"
+            ],
+            8,
+            [
+              "secondary_construction"
+            ],
+            7,
+            [
+              "tertiary_construction"
+            ],
+            6,
+            [
+              "minor_construction",
+              "service_construction",
+              "track_construction"
+            ],
+            4,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction",
+              "trunk_construction",
+              "primary_construction"
+            ],
+            24,
+            [
+              "secondary_construction"
+            ],
+            24,
+            [
+              "tertiary_construction"
+            ],
+            24,
+            [
+              "minor_construction",
+              "service_construction",
+              "track_construction"
+            ],
+            16,
+            16
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "motorway_construction",
+        "trunk_construction",
+        "primary_construction",
+        "secondary_construction",
+        "tertiary_construction",
+        "minor_construction",
+        "service_construction",
+        "track_construction"
+      ]
+    },
+    {
+      "id": "Minor road",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,100%)",
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          0.5,
+          10,
+          1,
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary",
+              "tertiary"
+            ],
+            1.5,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            1,
+            1
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            4,
+            [
+              "tertiary"
+            ],
+            3,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            2,
+            2
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            7,
+            [
+              "tertiary"
+            ],
+            6,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            4,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            24,
+            [
+              "tertiary"
+            ],
+            24,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            16,
+            16
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "!in",
+          "class",
+          "aerialway",
+          "bridge",
+          "ferry",
+          "minor_construction",
+          "motorway",
+          "motorway_construction",
+          "path",
+          "path_construction",
+          "pier",
+          "primary",
+          "primary_construction",
+          "rail",
+          "secondary_construction",
+          "service_construction",
+          "tertiary_construction",
+          "track_construction",
+          "transit",
+          "trunk_construction"
+        ]
+      ]
+    },
+    {
+      "id": "Major road",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(48,100%,83%)",
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            1.5,
+            1
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            2.5,
+            1
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk"
+            ],
+            3,
+            [
+              "primary"
+            ],
+            5,
+            2
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            8,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            24,
+            16
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
+      ]
+    },
+    {
+      "id": "Highway",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(35,100%,76%)",
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          0.5,
+          6,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "brunnel"
+              ],
+              [
+                "bridge"
+              ],
+              0,
+              1
+            ],
+            0
+          ],
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              0,
+              2.5
+            ],
+            1
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              1,
+              4
+            ],
+            1
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              5,
+              6
+            ],
+            2
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            8,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            24,
+            16
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
+      ]
+    },
+    {
+      "id": "Path outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "miter",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,100%)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              0
+            ],
+            [
+              16,
+              0
+            ],
+            [
+              18,
+              4
+            ],
+            [
+              22,
+              8
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "path",
+          "pedestrian"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ]
+    },
+    {
+      "id": "Path minor",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 79%)",
+        "line-dasharray": {
+          "stops": [
+            [
+              14,
+              [
+                1,
+                0.5
+              ]
+            ],
+            [
+              18,
+              [
+                1,
+                0.25
+              ]
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              2
+            ],
+            [
+              22,
+              5
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "path_pedestrian"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ]
+    },
+    {
+      "id": "Path",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 79%)",
+        "line-dasharray": {
+          "stops": [
+            [
+              14,
+              [
+                1,
+                0.5
+              ]
+            ],
+            [
+              18,
+              [
+                1,
+                0.25
+              ]
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              2
+            ],
+            [
+              22,
+              5
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "path",
+          "pedestrian"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ]
+    },
+    {
+      "id": "Major rail",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              8,
+              "hsl(0,0%,72%)"
+            ],
+            [
+              16,
+              "hsl(0,0%,70%)"
+            ]
+          ]
+        },
+        "line-opacity": [
+          "match",
+          [
+            "get",
+            "service"
+          ],
+          "yard",
+          0.5,
+          1
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ]
+    },
+    {
+      "id": "Major rail hatching",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,72%)",
+        "line-dasharray": [
+          0.2,
+          9
+        ],
+        "line-opacity": [
+          "match",
+          [
+            "get",
+            "service"
+          ],
+          "yard",
+          0.5,
+          1
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ]
+    },
+    {
+      "id": "Minor rail",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,73%)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "subclass",
+        "light_rail",
+        "tram"
+      ]
+    },
+    {
+      "id": "Minor rail hatching",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,73%)",
+        "line-dasharray": [
+          0.2,
+          4
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "subclass",
+        "tram",
+        "light_rail"
+      ]
+    },
+    {
+      "id": "Building",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "building",
+      "minzoom": 13,
+      "maxzoom": 15,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(30,6%,73%)",
+        "fill-opacity": 0.3,
+        "fill-outline-color": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              "hsla(35, 6%, 79%, 0.3)"
+            ],
+            [
+              14,
+              "hsl(35, 6%, 79%)"
+            ]
+          ]
+        }
+      },
+      "metadata": {}
+    },
+    {
+      "id": "Building 3D",
+      "type": "fill-extrusion",
+      "source": "maptiler_planet",
+      "source-layer": "building",
+      "minzoom": 15,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-extrusion-base": {
+          "property": "render_min_height",
+          "type": "identity"
+        },
+        "fill-extrusion-color": "hsl(44,14%,79%)",
+        "fill-extrusion-height": {
+          "property": "render_height",
+          "type": "identity"
+        },
+        "fill-extrusion-opacity": 0.4
+      },
+      "metadata": {},
+      "filter": [
+        "!has",
+        "hide_3d"
+      ]
+    },
+    {
+      "id": "Aqueduct outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "waterway",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,51%)",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              14,
+              1
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "brunnel",
+        "bridge"
+      ]
+    },
+    {
+      "id": "Aqueduct",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "waterway",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(204,92%,75%)",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              20,
+              5
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ]
+    },
+    {
+      "id": "Cablecar",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-blur": 1,
+        "line-color": "hsl(0,0%,100%)",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              2
+            ],
+            [
+              19,
+              4
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "aerialway"
+      ]
+    },
+    {
+      "id": "Cablecar dash",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,64%)",
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              1
+            ],
+            [
+              19,
+              2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "aerialway"
+      ]
+    },
+    {
+      "id": "Other border",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "boundary",
+      "minzoom": 3,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 70%)",
+        "line-dasharray": [
+          2,
+          1
+        ],
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          0.75,
+          4,
+          0.8,
+          11,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "admin_level"
+              ],
+              6
+            ],
+            1.75,
+            1.5
+          ],
+          18,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "admin_level"
+              ],
+              6
+            ],
+            3,
+            2
+          ]
+        ]
+      },
+      "filter": [
+        "all",
+        [
+          "in",
+          "admin_level",
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ]
+    },
+    {
+      "id": "Disputed border",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "boundary",
+      "minzoom": 0,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 63%)",
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-width": {
+          "stops": [
+            [
+              1,
+              0.5
+            ],
+            [
+              5,
+              1.5
+            ],
+            [
+              10,
+              2
+            ],
+            [
+              24,
+              12
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "==",
+          "disputed",
+          1
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ]
+    },
+    {
+      "id": "Country border",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "boundary",
+      "minzoom": 0,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 54%)",
+        "line-width": {
+          "stops": [
+            [
+              1,
+              0.5
+            ],
+            [
+              5,
+              1.5
+            ],
+            [
+              10,
+              2
+            ],
+            [
+              24,
+              12
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "==",
+          "disputed",
+          0
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ]
+    },
+    {
+      "id": "River labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "waterway",
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 400,
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Italic",
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": {
+          "stops": [
+            [
+              12,
+              8
+            ],
+            [
+              16,
+              14
+            ],
+            [
+              22,
+              20
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(205,84%,39%)",
+        "text-halo-blur": 1,
+        "text-halo-color": "hsl(202, 76%, 82%)",
+        "text-halo-width": {
+          "stops": [
+            [
+              10,
+              1
+            ],
+            [
+              18,
+              2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "$type",
+        "LineString"
+      ]
+    },
+    {
+      "id": "Ocean labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "water_name",
+      "minzoom": 0,
+      "layout": {
+        "symbol-placement": "point",
+        "text-field": "{name:en}",
+        "text-font": [
+          "Roboto Italic",
+          "Noto Sans Italic"
+        ],
+        "text-max-width": 5,
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          1,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ocean"
+            ],
+            14,
+            10
+          ],
+          3,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ocean"
+            ],
+            18,
+            14
+          ],
+          9,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ocean"
+            ],
+            22,
+            18
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "lake"
+            ],
+            14,
+            [
+              "sea"
+            ],
+            20,
+            26
+          ]
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": {
+          "stops": [
+            [
+              1,
+              "hsl(203,54%,54%)"
+            ],
+            [
+              4,
+              "hsl(203,72%,39%)"
+            ]
+          ]
+        },
+        "text-halo-blur": 1,
+        "text-halo-color": {
+          "stops": [
+            [
+              1,
+              "hsla(196, 72%, 80%, 0.05)"
+            ],
+            [
+              3,
+              "hsla(200, 100%, 88%, 0.75)"
+            ]
+          ]
+        },
+        "text-halo-width": 1,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          1,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ocean"
+            ],
+            1,
+            0
+          ],
+          3,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "has",
+          "name"
+        ],
+        [
+          "!=",
+          "class",
+          "lake"
+        ]
+      ]
+    },
+    {
+      "id": "Lake labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "water_name",
+      "minzoom": 0,
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Italic",
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 5,
+        "text-size": {
+          "stops": [
+            [
+              10,
+              13
+            ],
+            [
+              14,
+              16
+            ],
+            [
+              22,
+              20
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(205,84%,39%)",
+        "text-halo-color": "hsla(0, 100%, 100%, 0.45)",
+        "text-halo-width": 1.5
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "class",
+          "lake"
+        ]
+      ]
+    },
+    {
+      "id": "Housenumber",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "housenumber",
+      "minzoom": 18,
+      "layout": {
+        "text-field": "{housenumber}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-size": 10,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(26,10%,44%)",
+        "text-halo-blur": 1,
+        "text-halo-color": "hsl(21,64%,96%)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Gondola",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "text-anchor": "center",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Italic",
+          "Noto Sans Italic"
+        ],
+        "text-offset": [
+          0.8,
+          0.8
+        ],
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              11
+            ],
+            [
+              15,
+              12
+            ],
+            [
+              18,
+              13
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,40%)",
+        "text-halo-blur": 1,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "subclass",
+        "gondola",
+        "cable_car"
+      ]
+    },
+    {
+      "id": "Ferry",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 12,
+      "layout": {
+        "symbol-placement": "line",
+        "text-anchor": "center",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Italic",
+          "Noto Sans Italic"
+        ],
+        "text-offset": [
+          0.8,
+          0.8
+        ],
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              11
+            ],
+            [
+              15,
+              12
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(205,84%,39%)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsla(0, 0%, 100%, 0.15)",
+        "text-halo-width": 1
+      },
+      "filter": [
+        "==",
+        "class",
+        "ferry"
+      ]
+    },
+    {
+      "id": "Oneway",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "layout": {
+        "icon-image": "oneway",
+        "icon-padding": 2,
+        "icon-rotate": [
+          "match",
+          [
+            "get",
+            "oneway"
+          ],
+          1,
+          0,
+          0
+        ],
+        "icon-rotation-alignment": "map",
+        "icon-size": {
+          "stops": [
+            [
+              16,
+              0.7
+            ],
+            [
+              19,
+              1
+            ]
+          ]
+        },
+        "symbol-placement": "line",
+        "symbol-spacing": 75,
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 65%)",
+        "icon-opacity": 0.5
+      },
+      "filter": [
+        "all",
+        [
+          "has",
+          "oneway"
+        ],
+        [
+          "in",
+          "class",
+          "motorway",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary",
+          "minor",
+          "service"
+        ]
+      ]
+    },
+    {
+      "id": "Road labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 8,
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-ignore-placement": false,
+        "icon-keep-upright": false,
+        "symbol-placement": "line",
+        "symbol-spacing": [
+          "step",
+          [
+            "zoom"
+          ],
+          250,
+          21,
+          1000
+        ],
+        "text-allow-overlap": false,
+        "text-anchor": "center",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-ignore-placement": false,
+        "text-justify": "center",
+        "text-max-width": 10,
+        "text-offset": [
+          0,
+          0.15
+        ],
+        "text-optional": false,
+        "text-size": {
+          "stops": [
+            [
+              13,
+              10
+            ],
+            [
+              14,
+              11
+            ],
+            [
+              18,
+              13
+            ],
+            [
+              22,
+              15
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 16%)",
+        "text-color": "hsl(0, 0%, 16%)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!in",
+          "subclass",
+          "gondola",
+          "cable_car"
+        ],
+        [
+          "!in",
+          "class",
+          "ferry",
+          "service"
+        ]
+      ]
+    },
+    {
+      "id": "Highway junction",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 16,
+      "layout": {
+        "icon-image": "exit_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "point",
+        "symbol-spacing": 200,
+        "symbol-z-order": "auto",
+        "text-field": "{ref}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-offset": [
+          0,
+          0.1
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 9,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,21%)",
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "filter": [
+        "all",
+        [
+          ">",
+          "ref_length",
+          0
+        ],
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "==",
+          "subclass",
+          "junction"
+        ]
+      ]
+    },
+    {
+      "id": "Highway shield",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 8,
+      "layout": {
+        "icon-image": "road_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "symbol-spacing": {
+          "stops": [
+            [
+              10,
+              200
+            ],
+            [
+              18,
+              400
+            ]
+          ]
+        },
+        "text-field": "{ref}",
+        "text-font": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          [
+            "literal",
+            [
+              "Roboto Bold",
+              "Noto Sans Bold"
+            ]
+          ],
+          [
+            "literal",
+            [
+              "Roboto Regular"
+            ]
+          ]
+        ],
+        "text-offset": [
+          0,
+          0.05
+        ],
+        "text-padding": 2,
+        "text-rotation-alignment": "viewport",
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 100%)",
+        "icon-halo-color": "hsl(0, 0%, 29%)",
+        "icon-halo-width": 1,
+        "text-color": "hsl(0, 0%, 29%)",
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 1
+      },
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!in",
+          "network",
+          "us-interstate",
+          "us-highway",
+          "us-state"
+        ],
+        [
+          "!in",
+          "class",
+          "path"
+        ]
+      ]
+    },
+    {
+      "id": "Highway shield (US)",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "layout": {
+        "icon-image": "{network}_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1.1,
+        "symbol-avoid-edges": true,
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              7,
+              "point"
+            ],
+            [
+              7,
+              "line"
+            ],
+            [
+              8,
+              "line"
+            ]
+          ]
+        },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          [
+            "literal",
+            [
+              "Roboto Bold",
+              "Noto Sans Bold"
+            ]
+          ],
+          [
+            "literal",
+            [
+              "Roboto Regular",
+              "Noto Sans Regular"
+            ]
+          ]
+        ],
+        "text-offset": [
+          0,
+          0.05
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 9,
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 100%)",
+        "icon-halo-color": "hsl(0, 0%, 29%)",
+        "icon-halo-width": 1,
+        "text-color": "hsl(0, 0%, 29%)",
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 0
+      },
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "network",
+          "us-highway",
+          "us-state"
+        ],
+        [
+          "!in",
+          "class",
+          "path"
+        ]
+      ]
+    },
+    {
+      "id": "Highway shield interstate top (US)",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "layout": {
+        "icon-image": "{network}_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              7,
+              "point"
+            ],
+            [
+              7,
+              "line"
+            ],
+            [
+              8,
+              "line"
+            ]
+          ]
+        },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          [
+            "literal",
+            [
+              "Roboto Bold",
+              "Noto Sans Bold"
+            ]
+          ],
+          [
+            "literal",
+            [
+              "Roboto Regular",
+              "Noto Sans Regular"
+            ]
+          ]
+        ],
+        "text-offset": [
+          0,
+          0.1
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 9,
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(21, 100%, 45%)",
+        "icon-halo-color": "rgba(255, 255, 255, 1)",
+        "icon-halo-width": 1,
+        "icon-translate": [
+          0,
+          -4
+        ],
+        "icon-translate-anchor": "viewport",
+        "text-color": "hsl(21, 100%, 45%)",
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 0
+      },
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "network",
+          "us-interstate"
+        ],
+        [
+          "!in",
+          "class",
+          "path"
+        ]
+      ]
+    },
+    {
+      "id": "Highway shield interstate (US)",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "layout": {
+        "icon-image": "{network}_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              7,
+              "point"
+            ],
+            [
+              7,
+              "line"
+            ],
+            [
+              8,
+              "line"
+            ]
+          ]
+        },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          [
+            "literal",
+            [
+              "Roboto Bold",
+              "Noto Sans Bold"
+            ]
+          ],
+          [
+            "literal",
+            [
+              "Roboto Regular",
+              "Noto Sans Regular"
+            ]
+          ]
+        ],
+        "text-offset": [
+          0,
+          0.1
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 9,
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(212, 79%, 42%)",
+        "icon-halo-color": "rgba(255, 255, 255, 1)",
+        "icon-halo-width": 1,
+        "text-color": "hsl(0, 0%, 100%)",
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 0,
+        "text-translate": [
+          0,
+          -0.5
+        ]
+      },
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "network",
+          "us-interstate"
+        ],
+        [
+          "!in",
+          "class",
+          "path"
+        ]
+      ]
+    },
+    {
+      "id": "Public",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 16,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "atm",
+            "bank",
+            "bbq",
+            "cemetery",
+            "courthouse",
+            "drinking_water",
+            "fire_station",
+            "fountain",
+            "hairdresser",
+            "office",
+            "post",
+            "prison",
+            "recycling",
+            "shower",
+            "telephone",
+            "toilets",
+            "townhall",
+            "town_hall"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "case",
+            [
+              "has",
+              "class"
+            ],
+            "",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(51, 10%, 40%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "atm",
+              "bank",
+              "cemetery",
+              "courthouse",
+              "townhall",
+              "town_hall"
+            ],
+            1,
+            0
+          ],
+          17,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "atm",
+              "bank",
+              "cemetery",
+              "courthouse",
+              "fire_station",
+              "townhall",
+              "town_hall",
+              "post"
+            ],
+            1,
+            0
+          ],
+          18,
+          1
+        ],
+        "text-color": "hsl(51, 10%, 40%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "atm",
+              "bank",
+              "cemetery",
+              "courthouse",
+              "townhall",
+              "town_hall"
+            ],
+            1,
+            0
+          ],
+          17,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "atm",
+              "bank",
+              "cemetery",
+              "courthouse",
+              "fire_station",
+              "townhall",
+              "town_hall",
+              "post"
+            ],
+            1,
+            0
+          ],
+          18,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "atm",
+          "bank",
+          "bbq",
+          "cemetery",
+          "courthouse",
+          "drinking_water",
+          "fire_station",
+          "fountain",
+          "hairdresser",
+          "office",
+          "post",
+          "prison",
+          "recycling",
+          "shower",
+          "telephone",
+          "toilets",
+          "townhall",
+          "town_hall"
+        ]
+      ]
+    },
+    {
+      "id": "Sport",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 16,
+      "layout": {
+        "icon-image": [
+          "coalesce",
+          [
+            "image",
+            [
+              "to-string",
+              [
+                "get",
+                "subclass"
+              ]
+            ]
+          ],
+          [
+            "image",
+            [
+              "get",
+              "class"
+            ]
+          ],
+          [
+            "image",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(129, 65%, 30%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "playground",
+              "pitch",
+              "stadium",
+              "sports_hall",
+              "swimming_pool"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(129, 65%, 30%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "playground",
+              "pitch",
+              "stadium",
+              "sports_hall",
+              "swimming_pool"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "american_football",
+          "athletics",
+          "archery",
+          "baseball",
+          "basketball",
+          "climbing",
+          "equestrian",
+          "fitness",
+          "fitness_centre",
+          "golf",
+          "motor",
+          "multi",
+          "playground",
+          "pitch",
+          "running",
+          "sauna",
+          "soccer",
+          "sport",
+          "stadium",
+          "sports_centre",
+          "sports_hall",
+          "swimming",
+          "swimming_area",
+          "swimming_pool",
+          "tennis",
+          "volleyball",
+          "water_park"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Education",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 15,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "college",
+            "childcare",
+            "dancing_school",
+            "driving_school",
+            "kindergarten",
+            "school",
+            "university"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "case",
+            [
+              "has",
+              "class"
+            ],
+            "",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(175, 50%, 40%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          15,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "university"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "school",
+              "university"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(175, 50%, 40%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          15,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "university"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "school",
+              "university"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "college",
+          "childcare",
+          "dancing_school",
+          "driving_school",
+          "kindergarten",
+          "school",
+          "university"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Tourism",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "apartment",
+            "aquarium",
+            "attraction",
+            "campsite",
+            "camp_site",
+            "caravan_site",
+            "castle",
+            "chalet",
+            "guest_house",
+            "hotel",
+            "hostel",
+            "information",
+            "lodging",
+            "motel",
+            "reservoir",
+            "ruins",
+            "theme_park",
+            "zoo"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "case",
+            [
+              "has",
+              "class"
+            ],
+            "",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(283, 55%, 35%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "attraction"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "attraction",
+              "castle",
+              "hotel",
+              "zoo"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(283, 55%, 35%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "attraction"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "attraction",
+              "castle",
+              "hotel",
+              "zoo"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "apartment",
+          "aquarium",
+          "attraction",
+          "campsite",
+          "camp_site",
+          "caravan_site",
+          "castle",
+          "chalet",
+          "guest_house",
+          "hotel",
+          "hostel",
+          "information",
+          "lodging",
+          "motel",
+          "reservoir",
+          "ruins",
+          "theme_park",
+          "zoo"
+        ],
+        [
+          "!=",
+          "subclass",
+          "board"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Culture",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-image": [
+          "coalesce",
+          [
+            "image",
+            [
+              "to-string",
+              [
+                "get",
+                "subclass"
+              ]
+            ]
+          ],
+          [
+            "image",
+            [
+              "get",
+              "class"
+            ]
+          ],
+          [
+            "image",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(315, 35%, 50%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "museum"
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "cinema",
+              "art_gallery",
+              "museum",
+              "theatre"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "cinema",
+              "art_gallery",
+              "library",
+              "museum",
+              "place_of_worship",
+              "theatre"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(315, 35%, 50%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "museum"
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "cinema",
+              "art_gallery",
+              "museum",
+              "theatre"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "cinema",
+              "art_gallery",
+              "library",
+              "museum",
+              "place_of_worship",
+              "theatre"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "art_gallery",
+          "archeological_site",
+          "cinema",
+          "community_centre",
+          "gallery",
+          "library",
+          "monastery",
+          "monument",
+          "museum",
+          "opera",
+          "place_of_worship",
+          "planetarium",
+          "theatre"
+        ],
+        [
+          "!=",
+          "subclass",
+          "artwork"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Shopping",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-image": [
+          "coalesce",
+          [
+            "image",
+            [
+              "to-string",
+              [
+                "get",
+                "subclass"
+              ]
+            ]
+          ],
+          [
+            "image",
+            [
+              "get",
+              "class"
+            ]
+          ],
+          [
+            "image",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(18, 17%, 30%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "mall"
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "mall",
+              "supermarket"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "bakery",
+              "chemist",
+              "mall",
+              "supermarket"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(18, 17%, 30%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "mall"
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "mall",
+              "supermarket"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "bakery",
+              "chemist",
+              "mall",
+              "supermarket"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "all",
+          [
+            "in",
+            "class",
+            "alcohol_shop",
+            "bakery",
+            "book",
+            "books",
+            "butcher",
+            "chemist",
+            "clothing_store",
+            "convenience",
+            "gift",
+            "grocery",
+            "laundry",
+            "mall",
+            "music",
+            "shop",
+            "supermarket"
+          ],
+          [
+            "has",
+            "name"
+          ]
+        ]
+      ]
+    },
+    {
+      "id": "Food",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "maxzoom": 22,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "bar",
+            "beer",
+            "cafe",
+            "fast_food",
+            "ice_cream",
+            "restaurant"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "biergarten",
+            "pub"
+          ],
+          "beer",
+          "",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "food_court"
+          ],
+          "restaurant",
+          "dot"
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(18, 24%, 44%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              20
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              99
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              499
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(18, 24%, 44%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              20
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              99
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              499
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "bar",
+          "beer",
+          "biergarten",
+          "cafe",
+          "fast_food",
+          "food_court",
+          "ice_cream",
+          "pub",
+          "restaurant"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Transport",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "aerialway",
+            "bicycle",
+            "bicycle_parking",
+            "car",
+            "car_rental",
+            "car_repair",
+            "charging_station",
+            "cycle_barrier",
+            "ferry_terminal",
+            "fuel",
+            "harbor",
+            "motorcycle_parking",
+            "parking",
+            "parking_garage",
+            "parking_paid"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "case",
+            [
+              "has",
+              "class"
+            ],
+            "dot",
+            ""
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(215, 81%, 35%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ferry_terminal",
+              "fuel",
+              "terminal"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "car",
+              "car_rental",
+              "car_repair",
+              "charging_station",
+              "ferry_terminal",
+              "fuel",
+              "harbor",
+              "heliport",
+              "highway_rest_area",
+              "terminal",
+              "toll"
+            ],
+            1,
+            0
+          ],
+          17,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "car",
+              "car_rental",
+              "car_repair",
+              "charging_station",
+              "ferry_terminal",
+              "fuel",
+              "harbor",
+              "heliport",
+              "highway_rest_area",
+              "parking",
+              "parking_garage",
+              "parking_paid",
+              "terminal",
+              "toll"
+            ],
+            1,
+            0
+          ],
+          18,
+          1
+        ],
+        "text-color": "hsl(215, 81%, 35%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ferry_terminal",
+              "fuel",
+              "terminal"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "car",
+              "car_rental",
+              "car_repair",
+              "charging_station",
+              "ferry_terminal",
+              "fuel",
+              "harbor",
+              "heliport",
+              "highway_rest_area",
+              "terminal",
+              "toll"
+            ],
+            1,
+            0
+          ],
+          17,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "car",
+              "car_rental",
+              "car_repair",
+              "charging_station",
+              "ferry_terminal",
+              "fuel",
+              "harbor",
+              "heliport",
+              "highway_rest_area",
+              "parking",
+              "parking_garage",
+              "parking_paid",
+              "terminal",
+              "toll"
+            ],
+            1,
+            0
+          ],
+          18,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "bicycle",
+          "bicycle_parking",
+          "bicycle_rental",
+          "car",
+          "car_rental",
+          "car_repair",
+          "charging_station",
+          "ferry_terminal",
+          "fuel",
+          "harbor",
+          "heliport",
+          "highway_rest_area",
+          "motorcycle_parking",
+          "parking",
+          "parking_garage",
+          "parking_paid",
+          "scooter",
+          "terminal",
+          "toll"
+        ]
+      ]
+    },
+    {
+      "id": "Park",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-anchor": "center",
+        "icon-image": "park",
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(82, 83%, 25%)",
+        "icon-halo-blur": 0,
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              10
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              99
+            ],
+            1,
+            0
+          ],
+          16,
+          1
+        ],
+        "text-color": "hsl(82, 83%, 25%)",
+        "text-halo-blur": 0,
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              10
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              99
+            ],
+            1,
+            0
+          ],
+          16,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "park"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Healthcare",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "clinic",
+            "dentist",
+            "doctors",
+            "doctor",
+            "first_aid",
+            "hospital",
+            "pharmacy",
+            "veterinary"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "case",
+            [
+              "has",
+              "class"
+            ],
+            "",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(6, 96%, 35%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "hospital"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "clinic",
+              "hospital"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(6, 96%, 35%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "hospital"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "clinic",
+              "hospital"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "clinic",
+          "dentist",
+          "doctors",
+          "first_aid",
+          "hospital",
+          "pharmacy",
+          "veterinary"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Place labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 4,
+      "layout": {
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "center",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-letter-spacing": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "suburb",
+            "neighborhood",
+            "neighbourhood",
+            "quarter",
+            "island"
+          ],
+          0.2,
+          0
+        ],
+        "text-max-width": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "island"
+          ],
+          6,
+          8
+        ],
+        "text-offset": [
+          0,
+          0
+        ],
+        "text-padding": 2,
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          11,
+          8,
+          13,
+          11,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "village",
+            12,
+            [
+              "suburb",
+              "neighbourhood",
+              "quarter",
+              "hamlet",
+              "isolated_dwelling"
+            ],
+            9,
+            "island",
+            8,
+            12
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "village",
+            18,
+            [
+              "suburb",
+              "neighbourhood",
+              "quarter",
+              "hamlet",
+              "isolated_dwelling"
+            ],
+            15,
+            "island",
+            11,
+            16
+          ]
+        ],
+        "text-transform": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "suburb",
+            "neighborhood",
+            "neighbourhood",
+            "quarter",
+            "island"
+          ],
+          "uppercase",
+          "none"
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,25%)",
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1.2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          1,
+          8,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "island"
+            ],
+            0,
+            1
+          ],
+          9,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "island"
+            ],
+            1,
+            1
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "!in",
+        "class",
+        "continent",
+        "country",
+        "state",
+        "region",
+        "province",
+        "city",
+        "town",
+        "place"
+      ]
+    },
+    {
+      "id": "Station",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 12,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "subclass"
+          ],
+          [
+            "bus_stop",
+            "subway"
+          ],
+          [
+            "get",
+            "subclass"
+          ],
+          "bus_station",
+          "bus_stop",
+          "station",
+          "railway",
+          "tram_stop",
+          "tramway",
+          [
+            "case",
+            [
+              "has",
+              "subclass"
+            ],
+            "dot",
+            ""
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-line-height": 0.9,
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.9
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              13,
+              11
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              16
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(215, 83%, 53%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          12,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "station"
+            ],
+            1,
+            0
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "station",
+              "subway",
+              "tram_stop"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "bus_stop",
+              "station",
+              "subway",
+              "tram_stop"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(215, 83%, 53%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          12,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "station"
+            ],
+            1,
+            0
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "station",
+              "subway",
+              "tram_stop"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "bus_stop",
+              "station",
+              "subway",
+              "tram_stop"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "bus",
+          "railway"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Airport gate",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "aeroway",
+      "minzoom": 15,
+      "layout": {
+        "text-field": "{ref}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              15,
+              10
+            ],
+            [
+              22,
+              18
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,40%)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "filter": [
+        "==",
+        "class",
+        "gate"
+      ]
+    },
+    {
+      "id": "Airport",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "aerodrome_label",
+      "minzoom": 8,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "international",
+          "airport",
+          "airfield"
+        ],
+        "icon-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          0.6,
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "international",
+            0.8,
+            0.6
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "international",
+            1,
+            0.8
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": {
+          "stops": [
+            [
+              8,
+              " "
+            ],
+            [
+              9,
+              "{iata}"
+            ],
+            [
+              12,
+              "{name:en}"
+            ]
+          ]
+        },
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-line-height": 1.2,
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          9,
+          9,
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "international",
+            10,
+            7
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "international",
+            13,
+            11
+          ]
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(215, 83%, 53%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          1,
+          10,
+          0.5,
+          12,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          1,
+          12,
+          2
+        ],
+        "icon-opacity": 1,
+        "text-color": "hsl(215, 83%, 53%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          1,
+          10,
+          0.5,
+          12,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          1,
+          12,
+          2
+        ]
+      },
+      "filter": [
+        "all",
+        [
+          "has",
+          "iata"
+        ],
+        [
+          "!in",
+          "class",
+          "public"
+        ]
+      ]
+    },
+    {
+      "id": "State labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 3,
+      "maxzoom": 9,
+      "layout": {
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 8,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              9
+            ],
+            [
+              5,
+              10
+            ],
+            [
+              6,
+              11
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(48,4%,44%)",
+        "text-halo-color": "hsla(0,0%,100%,0.75)",
+        "text-halo-width": 0.8,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          3,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              3
+            ],
+            1,
+            0
+          ],
+          8,
+          [
+            "case",
+            [
+              "==",
+              [
+                "get",
+                "rank"
+              ],
+              0
+            ],
+            0,
+            1
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "state",
+          "province"
+        ],
+        [
+          "<=",
+          "rank",
+          6
+        ]
+      ]
+    },
+    {
+      "id": "Town labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 4,
+      "maxzoom": 16,
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": {
+          "stops": [
+            [
+              6,
+              "circle"
+            ],
+            [
+              12,
+              " "
+            ]
+          ]
+        },
+        "icon-optional": false,
+        "icon-size": [
+          "interpolate",
+          [
+            "exponential",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0.3,
+          14,
+          0.4
+        ],
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "bottom",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          -0.15
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              12
+            ],
+            11,
+            10
+          ],
+          9,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              15
+            ],
+            13,
+            12
+          ],
+          16,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              15
+            ],
+            22,
+            20
+          ]
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 20%, 99%)",
+        "icon-halo-color": "hsl(0, 0%, 29%)",
+        "icon-halo-width": 1,
+        "text-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          "hsl(0,0%,20%)",
+          12,
+          "hsl(0,0%,0%)"
+        ],
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "town"
+      ]
+    },
+    {
+      "id": "City labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 4,
+      "maxzoom": 16,
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": [
+          "step",
+          [
+            "zoom"
+          ],
+          "circle",
+          13,
+          ""
+        ],
+        "icon-optional": false,
+        "icon-size": 0.4,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "bottom",
+        "text-field": "{name:en}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          -0.15
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              2
+            ],
+            14,
+            12
+          ],
+          8,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            18,
+            14
+          ],
+          12,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            24,
+            18
+          ],
+          16,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            32,
+            26
+          ]
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 100%)",
+        "icon-halo-color": "hsl(0, 0%, 29%)",
+        "icon-halo-width": 1,
+        "icon-opacity": 1,
+        "text-color": "hsl(0,0%,20%)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 0.8
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "!=",
+          "capital",
+          2
+        ]
+      ]
+    },
+    {
+      "id": "Capital city labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 4,
+      "maxzoom": 16,
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": [
+          "step",
+          [
+            "zoom"
+          ],
+          "circle",
+          13,
+          ""
+        ],
+        "icon-optional": false,
+        "icon-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          0.45,
+          10,
+          0.5,
+          11,
+          0.6
+        ],
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "bottom",
+        "text-field": "{name:en}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          -0.15
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          14,
+          8,
+          18,
+          12,
+          24,
+          16,
+          32
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 100%)",
+        "icon-halo-color": "hsl(0, 0%, 29%)",
+        "icon-halo-width": 1,
+        "icon-opacity": 1,
+        "text-color": "hsl(0,0%,20%)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 0.8
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "capital",
+          2
+        ]
+      ]
+    },
+    {
+      "id": "Country labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 1,
+      "maxzoom": 12,
+      "layout": {
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-allow-overlap": false,
+        "text-field": "{name:en}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-letter-spacing": 0.07,
+        "text-max-width": {
+          "stops": [
+            [
+              1,
+              5
+            ],
+            [
+              5,
+              8
+            ]
+          ]
+        },
+        "text-padding": 1,
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          0,
+          8,
+          1,
+          10,
+          4,
+          [
+            "case",
+            [
+              ">",
+              [
+                "get",
+                "rank"
+              ],
+              2
+            ],
+            15,
+            17
+          ],
+          8,
+          [
+            "case",
+            [
+              ">",
+              [
+                "get",
+                "rank"
+              ],
+              2
+            ],
+            19,
+            23
+          ]
+        ],
+        "text-transform": "none",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0, 0%, 20%)",
+        "text-halo-blur": 0.8,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1,
+        "text-opacity": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          [
+            "case",
+            [
+              ">",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            0,
+            1
+          ],
+          5.9,
+          [
+            "case",
+            [
+              ">",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            0,
+            1
+          ],
+          6,
+          [
+            "case",
+            [
+              ">",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            1,
+            1
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          "has",
+          "iso_a2"
+        ],
+        [
+          "!=",
+          "iso_a2",
+          "VA"
+        ]
+      ]
+    },
+    {
+      "id": "Continent labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "maxzoom": 1,
+      "layout": {
+        "text-field": "{name:en}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-justify": "center",
+        "text-size": {
+          "stops": [
+            [
+              0,
+              12
+            ],
+            [
+              2,
+              13
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,19%)",
+        "text-halo-blur": 1,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "continent"
+      ]
+    }
+  ],
+  "metadata": {
+    "maptiler": {
+      "copyright": "You are licensed to use the style or its derivate for serving map tiles exclusively with MapTiler Server or MapTiler Cloud and in accordance with their licenses and terms. If you plan to use the style in a different way, contact us at sales@maptiler.com.",
+      "groups": [
+        {
+          "icon": "poi",
+          "id": "poi",
+          "layers": [
+            "Station",
+            "Public",
+            "Healthcare",
+            "Culture",
+            "Education",
+            "Food",
+            "Shopping",
+            "Sport",
+            "Tourism",
+            "Transport"
+          ],
+          "name": "POI"
+        },
+        {
+          "icon": "administrative",
+          "id": "administrative",
+          "layers": [
+            "Continent labels",
+            "Country labels",
+            "City labels",
+            "Town labels",
+            "State labels",
+            "Place labels",
+            "Country border",
+            "Disputed border",
+            "Other border",
+            "Capital city labels"
+          ],
+          "name": "Administrative"
+        },
+        {
+          "icon": "builtUp",
+          "id": "builtup",
+          "layers": [
+            "Building 3D",
+            "Building",
+            "Residential",
+            "Industrial",
+            "School",
+            "Stadium",
+            "Hospital",
+            "Cemetery"
+          ],
+          "name": "Built-up"
+        },
+        {
+          "icon": "transport",
+          "id": "transport",
+          "layers": [
+            "Ferry",
+            "Highway shield (US)",
+            "Highway shield",
+            "Highway junction",
+            "Gondola",
+            "Oneway",
+            "Housenumber",
+            "Road labels",
+            "Cablecar dash",
+            "Cablecar",
+            "Minor rail hatching",
+            "Minor rail",
+            "Major rail hatching",
+            "Major rail",
+            "Path",
+            "Path outline",
+            "Road under construction",
+            "Footway tunnel",
+            "Footway tunnel outline",
+            "Railway tunnel hatching",
+            "Railway tunnel",
+            "Tunnel",
+            "Tunnel outline",
+            "Bridge",
+            "Pier",
+            "Pier road",
+            "Pedestrian",
+            "Highway",
+            "Highway outline",
+            "Major road",
+            "Major road outline",
+            "Minor road",
+            "Minor road outline",
+            "Ferry line",
+            "Highway shield interstate (US)",
+            "Highway shield interstate top (US)",
+            "Airport",
+            "Airport gate",
+            "Airport zone",
+            "Aeroway",
+            "Heliport",
+            "Path minor",
+            "Bridge outline"
+          ],
+          "name": "Transport"
+        },
+        {
+          "icon": "water",
+          "id": "water",
+          "layers": [
+            "Aqueduct",
+            "Aqueduct outline",
+            "River",
+            "River tunnel",
+            "River labels",
+            "Water",
+            "Lake labels",
+            "Ocean labels",
+            "Water intermittent"
+          ],
+          "name": "Water"
+        },
+        {
+          "icon": "nature",
+          "id": "nature",
+          "layers": [
+            "Sand",
+            "Forest",
+            "Glacier",
+            "Meadow",
+            "Wood",
+            "Grass",
+            "Crop",
+            "Scrub",
+            "Park"
+          ],
+          "name": "Nature"
+        },
+        {
+          "icon": "background",
+          "id": "background",
+          "layers": [
+            "Background"
+          ],
+          "name": "Background"
+        }
+      ]
+    },
+    "spaceColor": "hsl(203, 100%, 85%)"
+  },
+  "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=mNLmXyaTH4gRlwJHSYWp",
+  "sprite": "https://api.maptiler.com/maps/streets-v2/sprite",
+  "bearing": 0,
+  "pitch": 0,
+  "center": [
+    0,
+    0
+  ],
+  "zoom": 1
+}

--- a/galileo-maplibre/src/lib.rs
+++ b/galileo-maplibre/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod style;
+pub use style::MaplibreStyle;

--- a/galileo-maplibre/src/style/expression.rs
+++ b/galileo-maplibre/src/style/expression.rs
@@ -1,0 +1,1946 @@
+//! Typed representation of MapLibre style expressions.
+//!
+//! A MapLibre expression is a JSON array whose first element is an operator
+//! string and whose remaining elements are arguments.  Arguments may themselves
+//! be expressions (nested arrays), or bare JSON primitives.
+//!
+//! This module provides [`Expr`], a recursive enum with one variant per
+//! operator group, plus a [`Literal`](Expr::Literal) variant for bare
+//! primitives.
+//!
+//! # Deserialization
+//!
+//! [`Expr`] implements [`serde::Deserialize`] with a custom visitor.  A JSON
+//! array is parsed as an expression (the first element names the operator); any
+//! other JSON value is stored as [`Expr::Literal`].
+//!
+//! # Operator reference
+//!
+//! The full operator list is drawn from the
+//! [MapLibre Style Spec — Expressions](https://maplibre.org/maplibre-style-spec/expressions/)
+//! page.  Each variant's doc-comment lists the corresponding operator string(s).
+
+use std::fmt;
+
+use serde::de::{self, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+/// The interpolation curve used by [`Expr::Interpolate`] and its color-space
+/// variants.
+///
+/// Encoded in JSON as a nested array: `["linear"]`, `["exponential", base]`,
+/// or `["cubic-bezier", x1, y1, x2, y2]`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Interpolation {
+    /// Linear interpolation: `["linear"]`.
+    Linear,
+    /// Exponential interpolation: `["exponential", base]`.
+    Exponential {
+        /// The exponential base — controls how quickly the output increases.
+        /// Values close to 1 behave linearly; higher values accelerate toward
+        /// the high end.
+        base: f64,
+    },
+    /// Cubic Bézier interpolation: `["cubic-bezier", x1, y1, x2, y2]`.
+    CubicBezier {
+        /// X-coordinate of the first control point (must be in [0, 1]).
+        x1: f64,
+        /// Y-coordinate of the first control point.
+        y1: f64,
+        /// X-coordinate of the second control point (must be in [0, 1]).
+        x2: f64,
+        /// Y-coordinate of the second control point.
+        y2: f64,
+    },
+}
+
+// Custom deserialization: the JSON shape is `["linear"]`, `["exponential", N]`,
+// or `["cubic-bezier", x1, y1, x2, y2]` — a flat array, not a struct.
+impl<'de> Deserialize<'de> for Interpolation {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct InterpVisitor;
+
+        impl<'de> Visitor<'de> for InterpVisitor {
+            type Value = Interpolation;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str(
+                    r#"an interpolation array: ["linear"], ["exponential", base], or ["cubic-bezier", x1, y1, x2, y2]"#,
+                )
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let name: String = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+
+                match name.as_str() {
+                    "linear" => Ok(Interpolation::Linear),
+                    "exponential" => {
+                        let base: f64 = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                        Ok(Interpolation::Exponential { base })
+                    }
+                    "cubic-bezier" => {
+                        let x1: f64 = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                        let y1: f64 = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+                        let x2: f64 = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(3, &self))?;
+                        let y2: f64 = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(4, &self))?;
+                        Ok(Interpolation::CubicBezier { x1, y1, x2, y2 })
+                    }
+                    other => Err(de::Error::unknown_variant(
+                        other,
+                        &["linear", "exponential", "cubic-bezier"],
+                    )),
+                }
+            }
+        }
+
+        // Interpolation can appear either as a nested array inside a larger
+        // expression array (where it arrives as a `Value`), or be deserialized
+        // directly.  Handle both.
+        d.deserialize_seq(InterpVisitor)
+    }
+}
+
+impl Serialize for Interpolation {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+        match self {
+            Interpolation::Linear => {
+                let mut seq = s.serialize_seq(Some(1))?;
+                seq.serialize_element("linear")?;
+                seq.end()
+            }
+            Interpolation::Exponential { base } => {
+                let mut seq = s.serialize_seq(Some(2))?;
+                seq.serialize_element("exponential")?;
+                seq.serialize_element(base)?;
+                seq.end()
+            }
+            Interpolation::CubicBezier { x1, y1, x2, y2 } => {
+                let mut seq = s.serialize_seq(Some(5))?;
+                seq.serialize_element("cubic-bezier")?;
+                seq.serialize_element(x1)?;
+                seq.serialize_element(y1)?;
+                seq.serialize_element(x2)?;
+                seq.serialize_element(y2)?;
+                seq.end()
+            }
+        }
+    }
+}
+
+/// A MapLibre style expression.
+///
+/// Expressions are the modern (post-v0.41.0) way to compute style property
+/// values from the current zoom level and/or feature properties.  They are
+/// represented in JSON as arrays: `["operator", arg1, arg2, ...]`.
+///
+/// # Deserialization
+///
+/// - A JSON **array** is parsed as an expression; the first element names the
+///   operator and the remainder are arguments.
+/// - Any other JSON value (number, string, bool, null, object) is stored as
+///   [`Expr::Literal`].
+///
+/// Unknown operators are preserved as [`Expr::Unknown`] so that future spec
+/// additions do not cause parse failures.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    /// A bare JSON primitive (number, string, boolean, null, object).
+    ///
+    /// Used wherever a sub-expression argument position holds a literal value
+    /// rather than a nested expression.
+    Literal(Value),
+
+    /// `["let", var_name_1, var_value_1, ..., result_expr]`
+    ///
+    /// Binds named variables then evaluates the result expression in that
+    /// scope.  Variable names must be string literals; their values are
+    /// arbitrary expressions.
+    Let {
+        /// Alternating `(name, value)` pairs.
+        bindings: Vec<(String, Box<Expr>)>,
+        /// The body expression evaluated in the binding scope.
+        body: Box<Expr>,
+    },
+
+    /// `["var", name]`
+    ///
+    /// References a variable bound by an enclosing `let` expression.
+    Var(String),
+
+    /// `["step", input, default_output, stop_input_1, stop_output_1, ...]`
+    ///
+    /// Piecewise-constant: returns the output of the last stop whose input
+    /// is ≤ the evaluated `input`, or `default_output` if the input is less
+    /// than the first stop.
+    Step {
+        /// The numeric input expression (e.g. `["zoom"]` or `["get", "pop"]`).
+        input: Box<Expr>,
+        /// Output when the input is below the first stop.
+        default_output: Box<Expr>,
+        /// `(threshold, output)` pairs in ascending order.
+        stops: Vec<(Expr, Expr)>,
+    },
+
+    /// `["interpolate", interp, input, stop_input_1, stop_output_1, ...]`
+    ///
+    /// Continuously interpolates between stop outputs.  Output type must be
+    /// `number`, `array<number>`, `color`, `array<color>`, or `projection`.
+    Interpolate {
+        /// The interpolation curve.
+        interpolation: Interpolation,
+        /// The numeric input expression.
+        input: Box<Expr>,
+        /// `(threshold, output)` pairs in ascending order.
+        stops: Vec<(Expr, Expr)>,
+    },
+
+    /// `["interpolate-hcl", interp, input, stop_input_1, stop_output_1, ...]`
+    ///
+    /// Like [`Interpolate`](Expr::Interpolate) but performed in the
+    /// Hue-Chroma-Luminance color space.  Output must be `color`.
+    InterpolateHcl {
+        /// The interpolation curve.
+        interpolation: Interpolation,
+        /// The numeric input expression.
+        input: Box<Expr>,
+        /// `(threshold, output)` pairs in ascending order.
+        stops: Vec<(Expr, Expr)>,
+    },
+
+    /// `["interpolate-lab", interp, input, stop_input_1, stop_output_1, ...]`
+    ///
+    /// Like [`Interpolate`](Expr::Interpolate) but performed in the CIELAB
+    /// color space.  Output must be `color`.
+    InterpolateLab {
+        /// The interpolation curve.
+        interpolation: Interpolation,
+        /// The numeric input expression.
+        input: Box<Expr>,
+        /// `(threshold, output)` pairs in ascending order.
+        stops: Vec<(Expr, Expr)>,
+    },
+
+    /// `["get", property]` or `["get", property, object_expr]`
+    ///
+    /// Retrieves a feature property (or a property from `object_expr`).
+    Get {
+        /// The property name expression (typically a string literal).
+        property: Box<Expr>,
+        /// Optional object to retrieve the property from.
+        object: Option<Box<Expr>>,
+    },
+
+    /// `["has", property]` or `["has", property, object_expr]`
+    ///
+    /// Tests whether a feature property (or a property in `object_expr`)
+    /// exists.
+    Has {
+        /// The property name expression.
+        property: Box<Expr>,
+        /// Optional object to test.
+        object: Option<Box<Expr>>,
+    },
+
+    /// `["at", index, array]`
+    ///
+    /// Retrieves the item at `index` from `array`.
+    At {
+        /// The zero-based index expression.
+        index: Box<Expr>,
+        /// The array expression.
+        array: Box<Expr>,
+    },
+
+    /// `["in", item, array_or_string]`
+    ///
+    /// Tests whether `item` is in `array_or_string`.
+    In {
+        /// The needle expression.
+        item: Box<Expr>,
+        /// The haystack expression (array or string).
+        array_or_string: Box<Expr>,
+    },
+
+    /// `["index-of", item, array_or_string]` or with an optional `from_index`.
+    ///
+    /// Returns the first index at which `item` appears, or -1.
+    IndexOf {
+        /// The needle expression.
+        item: Box<Expr>,
+        /// The haystack expression.
+        array_or_string: Box<Expr>,
+        /// Optional start index for the search.
+        from_index: Option<Box<Expr>>,
+    },
+
+    /// `["slice", array_or_string, start]` or `["slice", ..., start, end]`.
+    ///
+    /// Returns a subarray or substring.
+    Slice {
+        /// The source expression.
+        array_or_string: Box<Expr>,
+        /// The inclusive start index.
+        start: Box<Expr>,
+        /// The exclusive end index (optional).
+        end: Option<Box<Expr>>,
+    },
+
+    /// `["length", array_or_string]`
+    ///
+    /// Returns the length of an array or string.
+    Length(Box<Expr>),
+
+    /// `["global-state", property_name]`
+    ///
+    /// Retrieves a property from global state set via platform APIs.
+    GlobalState(Box<Expr>),
+
+    /// `["case", cond_1, out_1, ..., cond_n, out_n, fallback]`
+    ///
+    /// Returns the output for the first condition that evaluates to `true`.
+    Case {
+        /// `(condition, output)` pairs evaluated in order.
+        branches: Vec<(Box<Expr>, Box<Expr>)>,
+        /// Output when no condition matches.
+        fallback: Box<Expr>,
+    },
+
+    /// `["match", input, label_1, out_1, ..., label_n, out_n, fallback]`
+    ///
+    /// Returns the output for the first label that equals `input`.  A label
+    /// may be a single value or an array of values.
+    Match {
+        /// The input expression.
+        input: Box<Expr>,
+        /// `(labels, output)` pairs; each label list contains one or more
+        /// literal values.
+        branches: Vec<(Vec<Value>, Box<Expr>)>,
+        /// Output when no label matches.
+        fallback: Box<Expr>,
+    },
+
+    /// `["coalesce", expr_1, ..., expr_n]`
+    ///
+    /// Evaluates each expression in order and returns the first non-null result.
+    Coalesce(Vec<Expr>),
+
+    /// `["all", input_1, ..., input_n]` — logical AND (short-circuit).
+    All(Vec<Expr>),
+
+    /// `["any", input_1, ..., input_n]` — logical OR (short-circuit).
+    Any(Vec<Expr>),
+
+    /// `["!", input]` — logical NOT.
+    Not(Box<Expr>),
+
+    /// `["==", a, b]` (with optional collator) — equality comparison.
+    Eq(Box<Expr>, Box<Expr>),
+
+    /// `["!=", a, b]` — inequality comparison.
+    Ne(Box<Expr>, Box<Expr>),
+
+    /// `[">", a, b]` — greater than.
+    Gt(Box<Expr>, Box<Expr>),
+
+    /// `[">=", a, b]` — greater than or equal.
+    Gte(Box<Expr>, Box<Expr>),
+
+    /// `["<", a, b]` — less than.
+    Lt(Box<Expr>, Box<Expr>),
+
+    /// `["<=", a, b]` — less than or equal.
+    Lte(Box<Expr>, Box<Expr>),
+
+    /// `["within", geojson]`
+    ///
+    /// Returns `true` if the feature is fully inside the given GeoJSON geometry.
+    Within(Value),
+
+    /// `["+", n_1, ..., n_n]` — sum.
+    Add(Vec<Expr>),
+
+    /// `["*", n_1, ..., n_n]` — product.
+    Mul(Vec<Expr>),
+
+    /// `["-", a, b]` or `["-", a]` — subtraction or negation.
+    Sub(Box<Expr>, Option<Box<Expr>>),
+
+    /// `["/", a, b]` — division.
+    Div(Box<Expr>, Box<Expr>),
+
+    /// `["%", a, b]` — modulo.
+    Mod(Box<Expr>, Box<Expr>),
+
+    /// `["^", base, exp]` — exponentiation.
+    Pow(Box<Expr>, Box<Expr>),
+
+    /// `["sqrt", n]` — square root.
+    Sqrt(Box<Expr>),
+
+    /// `["abs", n]` — absolute value.
+    Abs(Box<Expr>),
+
+    /// `["ceil", n]` — ceiling.
+    Ceil(Box<Expr>),
+
+    /// `["floor", n]` — floor.
+    Floor(Box<Expr>),
+
+    /// `["round", n]` — round to nearest integer (half away from zero).
+    Round(Box<Expr>),
+
+    /// `["min", n_1, ..., n_n]` — minimum.
+    Min(Vec<Expr>),
+
+    /// `["max", n_1, ..., n_n]` — maximum.
+    Max(Vec<Expr>),
+
+    /// `["log2", n]` — base-2 logarithm.
+    Log2(Box<Expr>),
+
+    /// `["log10", n]` — base-10 logarithm.
+    Log10(Box<Expr>),
+
+    /// `["ln", n]` — natural logarithm.
+    Ln(Box<Expr>),
+
+    /// `["sin", n]` — sine (radians).
+    Sin(Box<Expr>),
+
+    /// `["cos", n]` — cosine (radians).
+    Cos(Box<Expr>),
+
+    /// `["tan", n]` — tangent (radians).
+    Tan(Box<Expr>),
+
+    /// `["asin", n]` — arcsine.
+    Asin(Box<Expr>),
+
+    /// `["acos", n]` — arccosine.
+    Acos(Box<Expr>),
+
+    /// `["atan", n]` — arctangent.
+    Atan(Box<Expr>),
+
+    /// `["ln2"]` — the mathematical constant ln(2).
+    Ln2,
+
+    /// `["pi"]` — the mathematical constant π.
+    Pi,
+
+    /// `["e"]` — the mathematical constant e.
+    E,
+
+    /// `["distance", geojson]`
+    ///
+    /// Returns the shortest distance in metres between the feature and the
+    /// given GeoJSON geometry.
+    Distance(Value),
+
+    /// `["rgb", r, g, b]` — constructs a color from RGB components (0–255).
+    Rgb(Box<Expr>, Box<Expr>, Box<Expr>),
+
+    /// `["rgba", r, g, b, a]` — constructs a color from RGBA components.
+    Rgba(Box<Expr>, Box<Expr>, Box<Expr>, Box<Expr>),
+
+    /// `["to-rgba", color]` — returns `[r, g, b, a]` components of a color.
+    ToRgba(Box<Expr>),
+
+    /// `["literal", value]` — wraps a JSON array or object as a literal.
+    LiteralExpr(Value),
+
+    /// `["typeof", value]` — returns a string describing the type of `value`.
+    TypeOf(Box<Expr>),
+
+    /// `["to-string", value]` — converts `value` to a string.
+    ToString(Box<Expr>),
+
+    /// `["to-number", value_1, ..., value_n]` — converts to a number.
+    ToNumber(Vec<Expr>),
+
+    /// `["to-boolean", value]` — converts to a boolean.
+    ToBoolean(Box<Expr>),
+
+    /// `["to-color", value_1, ..., value_n]` — converts to a color.
+    ToColor(Vec<Expr>),
+
+    /// `["number", value_1, ..., value_n]` — asserts input is a number.
+    NumberAssertion(Vec<Expr>),
+
+    /// `["string", value_1, ..., value_n]` — asserts input is a string.
+    StringAssertion(Vec<Expr>),
+
+    /// `["boolean", value_1, ..., value_n]` — asserts input is a boolean.
+    BooleanAssertion(Vec<Expr>),
+
+    /// `["object", value_1, ..., value_n]` — asserts input is an object.
+    ObjectAssertion(Vec<Expr>),
+
+    /// `["array", value]` / `["array", type, value]` / `["array", type, length, value]`
+    ///
+    /// Asserts input is an array, optionally with element type and length.
+    ArrayAssertion {
+        /// Optional element type assertion (`"string"`, `"number"`, `"boolean"`).
+        element_type: Option<String>,
+        /// Optional expected array length.
+        length: Option<u64>,
+        /// The value to assert.
+        value: Box<Expr>,
+    },
+
+    /// `["collator", options]` — returns a locale-aware collator.
+    Collator(Value),
+
+    /// `["format", input_1, style_1?, ..., input_n, style_n?]`
+    ///
+    /// Returns a `formatted` string for rich text labels.  Each section is a
+    /// `(content, style_overrides)` pair.
+    Format(Vec<(Box<Expr>, Option<Value>)>),
+
+    /// `["image", name]` — returns an image for use in icons/patterns.
+    Image(Box<Expr>),
+
+    /// `["number-format", input, options]` — formats a number as a string.
+    NumberFormat {
+        /// The number expression to format.
+        input: Box<Expr>,
+        /// Formatting options object (locale, currency, min/max fraction digits, etc.).
+        options: Value,
+    },
+
+    /// `["get", ...]` — see [`Expr::Get`] (aliased here for feature state).
+    ///
+    /// `["feature-state", property]` — retrieves a property from feature state.
+    FeatureState(Box<Expr>),
+
+    /// `["geometry-type"]` — returns `"Point"`, `"LineString"`, or `"Polygon"`.
+    GeometryType,
+
+    /// `["id"]` — returns the feature's id.
+    Id,
+
+    /// `["properties"]` — returns the feature's properties object.
+    Properties,
+
+    /// `["accumulated"]` — gets the accumulated cluster property value.
+    Accumulated,
+
+    /// `["line-progress"]` — gets the progress along a gradient line.
+    LineProgress,
+
+    /// `["zoom"]` — the current map zoom level.
+    Zoom,
+
+    /// `["heatmap-density"]` — kernel density estimate at the current pixel.
+    HeatmapDensity,
+
+    /// `["elevation"]` — elevation in metres at the current pixel.
+    Elevation,
+
+    /// `["upcase", s]` — converts string to uppercase.
+    Upcase(Box<Expr>),
+
+    /// `["downcase", s]` — converts string to lowercase.
+    Downcase(Box<Expr>),
+
+    /// `["concat", s_1, ..., s_n]` — concatenates strings.
+    Concat(Vec<Expr>),
+
+    /// `["is-supported-script", s]` — returns `true` if the string renders legibly.
+    IsSupportedScript(Box<Expr>),
+
+    /// `["resolved-locale", collator]` — returns the IETF tag of the locale in use.
+    ResolvedLocale(Box<Expr>),
+
+    /// `["split", input, separator]` — splits a string into an array.
+    Split(Box<Expr>, Box<Expr>),
+
+    /// `["join", array, separator]` — joins an array into a string.
+    Join(Box<Expr>, Box<Expr>),
+
+    /// An unrecognised operator.
+    ///
+    /// Preserved so that unknown/future operators do not cause a parse failure.
+    /// The first element is the operator string; the rest are raw argument values.
+    Unknown {
+        /// The unrecognised operator name.
+        operator: String,
+        /// The raw JSON arguments.
+        args: Vec<Value>,
+    },
+}
+
+impl Expr {
+    /// Returns the operator name for this expression, or `None` for
+    /// [`Expr::Literal`] and [`Expr::LiteralExpr`].
+    ///
+    /// Useful for quick operator-based dispatch in the renderer.
+    pub fn operator(&self) -> Option<&str> {
+        Some(match self {
+            // Variable binding
+            Expr::Let { .. } => "let",
+            Expr::Var(_) => "var",
+            // Ramps / curves
+            Expr::Step { .. } => "step",
+            Expr::Interpolate { .. } => "interpolate",
+            Expr::InterpolateHcl { .. } => "interpolate-hcl",
+            Expr::InterpolateLab { .. } => "interpolate-lab",
+            // Lookup
+            Expr::Get { .. } => "get",
+            Expr::Has { .. } => "has",
+            Expr::At { .. } => "at",
+            Expr::In { .. } => "in",
+            Expr::IndexOf { .. } => "index-of",
+            Expr::Slice { .. } => "slice",
+            Expr::Length(_) => "length",
+            Expr::GlobalState(_) => "global-state",
+            // Decision
+            Expr::Case { .. } => "case",
+            Expr::Match { .. } => "match",
+            Expr::Coalesce(_) => "coalesce",
+            Expr::All(_) => "all",
+            Expr::Any(_) => "any",
+            Expr::Not(_) => "!",
+            Expr::Eq(_, _) => "==",
+            Expr::Ne(_, _) => "!=",
+            Expr::Gt(_, _) => ">",
+            Expr::Gte(_, _) => ">=",
+            Expr::Lt(_, _) => "<",
+            Expr::Lte(_, _) => "<=",
+            Expr::Within(_) => "within",
+            // Math
+            Expr::Add(_) => "+",
+            Expr::Mul(_) => "*",
+            Expr::Sub(_, _) => "-",
+            Expr::Div(_, _) => "/",
+            Expr::Mod(_, _) => "%",
+            Expr::Pow(_, _) => "^",
+            Expr::Sqrt(_) => "sqrt",
+            Expr::Abs(_) => "abs",
+            Expr::Ceil(_) => "ceil",
+            Expr::Floor(_) => "floor",
+            Expr::Round(_) => "round",
+            Expr::Min(_) => "min",
+            Expr::Max(_) => "max",
+            Expr::Log2(_) => "log2",
+            Expr::Log10(_) => "log10",
+            Expr::Ln(_) => "ln",
+            Expr::Sin(_) => "sin",
+            Expr::Cos(_) => "cos",
+            Expr::Tan(_) => "tan",
+            Expr::Asin(_) => "asin",
+            Expr::Acos(_) => "acos",
+            Expr::Atan(_) => "atan",
+            Expr::Ln2 => "ln2",
+            Expr::Pi => "pi",
+            Expr::E => "e",
+            Expr::Distance(_) => "distance",
+            // Color
+            Expr::Rgb(_, _, _) => "rgb",
+            Expr::Rgba(_, _, _, _) => "rgba",
+            Expr::ToRgba(_) => "to-rgba",
+            // Type operators
+            Expr::LiteralExpr(_) => "literal",
+            Expr::TypeOf(_) => "typeof",
+            Expr::ToString(_) => "to-string",
+            Expr::ToNumber(_) => "to-number",
+            Expr::ToBoolean(_) => "to-boolean",
+            Expr::ToColor(_) => "to-color",
+            Expr::NumberAssertion(_) => "number",
+            Expr::StringAssertion(_) => "string",
+            Expr::BooleanAssertion(_) => "boolean",
+            Expr::ObjectAssertion(_) => "object",
+            Expr::ArrayAssertion { .. } => "array",
+            Expr::Collator(_) => "collator",
+            Expr::Format(_) => "format",
+            Expr::Image(_) => "image",
+            Expr::NumberFormat { .. } => "number-format",
+            // Feature data
+            Expr::FeatureState(_) => "feature-state",
+            Expr::GeometryType => "geometry-type",
+            Expr::Id => "id",
+            Expr::Properties => "properties",
+            Expr::Accumulated => "accumulated",
+            Expr::LineProgress => "line-progress",
+            // Camera
+            Expr::Zoom => "zoom",
+            // Heatmap
+            Expr::HeatmapDensity => "heatmap-density",
+            // Color relief
+            Expr::Elevation => "elevation",
+            // String
+            Expr::Upcase(_) => "upcase",
+            Expr::Downcase(_) => "downcase",
+            Expr::Concat(_) => "concat",
+            Expr::IsSupportedScript(_) => "is-supported-script",
+            Expr::ResolvedLocale(_) => "resolved-locale",
+            Expr::Split(_, _) => "split",
+            Expr::Join(_, _) => "join",
+            // Unknown
+            Expr::Unknown { operator, .. } => operator.as_str(),
+            // No operator for bare literals
+            Expr::Literal(_) => return None,
+        })
+    }
+}
+
+impl Serialize for Expr {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        // Convert to a serde_json::Value first, then serialize that.
+        // This lets us produce the exact JSON array format `["op", arg1, ...]`.
+        let v = expr_to_value(self);
+        v.serialize(s)
+    }
+}
+
+/// Convert an [`Expr`] to a [`Value`] that matches the MapLibre JSON array
+/// format for expressions.
+fn expr_to_value(e: &Expr) -> Value {
+    match e {
+        Expr::Literal(v) => v.clone(),
+        Expr::LiteralExpr(v) => Value::Array(vec![Value::String("literal".into()), v.clone()]),
+
+        // Variable binding
+        Expr::Let { bindings, body } => {
+            let mut arr = vec![Value::String("let".into())];
+            for (name, val) in bindings {
+                arr.push(Value::String(name.clone()));
+                arr.push(expr_to_value(val));
+            }
+            arr.push(expr_to_value(body));
+            Value::Array(arr)
+        }
+        Expr::Var(name) => Value::Array(vec![
+            Value::String("var".into()),
+            Value::String(name.clone()),
+        ]),
+
+        // Ramps / curves
+        Expr::Step {
+            input,
+            default_output,
+            stops,
+        } => {
+            let mut arr = vec![
+                Value::String("step".into()),
+                expr_to_value(input),
+                expr_to_value(default_output),
+            ];
+            for (inp, out) in stops {
+                arr.push(expr_to_value(inp));
+                arr.push(expr_to_value(out));
+            }
+            Value::Array(arr)
+        }
+        Expr::Interpolate {
+            interpolation,
+            input,
+            stops,
+        } => interp_to_array("interpolate", interpolation, input, stops),
+        Expr::InterpolateHcl {
+            interpolation,
+            input,
+            stops,
+        } => interp_to_array("interpolate-hcl", interpolation, input, stops),
+        Expr::InterpolateLab {
+            interpolation,
+            input,
+            stops,
+        } => interp_to_array("interpolate-lab", interpolation, input, stops),
+
+        // Lookup
+        Expr::Get { property, object } => opt_object_array("get", property, object.as_deref()),
+        Expr::Has { property, object } => opt_object_array("has", property, object.as_deref()),
+        Expr::At { index, array } => Value::Array(vec![
+            Value::String("at".into()),
+            expr_to_value(index),
+            expr_to_value(array),
+        ]),
+        Expr::In {
+            item,
+            array_or_string,
+        } => Value::Array(vec![
+            Value::String("in".into()),
+            expr_to_value(item),
+            expr_to_value(array_or_string),
+        ]),
+        Expr::IndexOf {
+            item,
+            array_or_string,
+            from_index,
+        } => {
+            let mut arr = vec![
+                Value::String("index-of".into()),
+                expr_to_value(item),
+                expr_to_value(array_or_string),
+            ];
+            if let Some(fi) = from_index {
+                arr.push(expr_to_value(fi));
+            }
+            Value::Array(arr)
+        }
+        Expr::Slice {
+            array_or_string,
+            start,
+            end,
+        } => {
+            let mut arr = vec![
+                Value::String("slice".into()),
+                expr_to_value(array_or_string),
+                expr_to_value(start),
+            ];
+            if let Some(e) = end {
+                arr.push(expr_to_value(e));
+            }
+            Value::Array(arr)
+        }
+        Expr::Length(inner) => {
+            Value::Array(vec![Value::String("length".into()), expr_to_value(inner)])
+        }
+        Expr::GlobalState(inner) => Value::Array(vec![
+            Value::String("global-state".into()),
+            expr_to_value(inner),
+        ]),
+
+        // Decision
+        Expr::Case { branches, fallback } => {
+            let mut arr = vec![Value::String("case".into())];
+            for (cond, out) in branches {
+                arr.push(expr_to_value(cond));
+                arr.push(expr_to_value(out));
+            }
+            arr.push(expr_to_value(fallback));
+            Value::Array(arr)
+        }
+        Expr::Match {
+            input,
+            branches,
+            fallback,
+        } => {
+            let mut arr = vec![Value::String("match".into()), expr_to_value(input)];
+            for (labels, out) in branches {
+                if labels.len() == 1 {
+                    arr.push(labels[0].clone());
+                } else {
+                    arr.push(Value::Array(labels.clone()));
+                }
+                arr.push(expr_to_value(out));
+            }
+            arr.push(expr_to_value(fallback));
+            Value::Array(arr)
+        }
+        Expr::Coalesce(args) => variadic_array("coalesce", args),
+        Expr::All(args) => variadic_array("all", args),
+        Expr::Any(args) => variadic_array("any", args),
+        Expr::Not(inner) => Value::Array(vec![Value::String("!".into()), expr_to_value(inner)]),
+        Expr::Eq(a, b) => binary_array("==", a, b),
+        Expr::Ne(a, b) => binary_array("!=", a, b),
+        Expr::Gt(a, b) => binary_array(">", a, b),
+        Expr::Gte(a, b) => binary_array(">=", a, b),
+        Expr::Lt(a, b) => binary_array("<", a, b),
+        Expr::Lte(a, b) => binary_array("<=", a, b),
+        Expr::Within(v) => Value::Array(vec![Value::String("within".into()), v.clone()]),
+
+        // Math
+        Expr::Add(args) => variadic_array("+", args),
+        Expr::Mul(args) => variadic_array("*", args),
+        Expr::Sub(a, None) => Value::Array(vec![Value::String("-".into()), expr_to_value(a)]),
+        Expr::Sub(a, Some(b)) => binary_array("-", a, b),
+        Expr::Div(a, b) => binary_array("/", a, b),
+        Expr::Mod(a, b) => binary_array("%", a, b),
+        Expr::Pow(a, b) => binary_array("^", a, b),
+        Expr::Sqrt(inner) => unary_array("sqrt", inner),
+        Expr::Abs(inner) => unary_array("abs", inner),
+        Expr::Ceil(inner) => unary_array("ceil", inner),
+        Expr::Floor(inner) => unary_array("floor", inner),
+        Expr::Round(inner) => unary_array("round", inner),
+        Expr::Min(args) => variadic_array("min", args),
+        Expr::Max(args) => variadic_array("max", args),
+        Expr::Log2(inner) => unary_array("log2", inner),
+        Expr::Log10(inner) => unary_array("log10", inner),
+        Expr::Ln(inner) => unary_array("ln", inner),
+        Expr::Sin(inner) => unary_array("sin", inner),
+        Expr::Cos(inner) => unary_array("cos", inner),
+        Expr::Tan(inner) => unary_array("tan", inner),
+        Expr::Asin(inner) => unary_array("asin", inner),
+        Expr::Acos(inner) => unary_array("acos", inner),
+        Expr::Atan(inner) => unary_array("atan", inner),
+        Expr::Ln2 => Value::Array(vec![Value::String("ln2".into())]),
+        Expr::Pi => Value::Array(vec![Value::String("pi".into())]),
+        Expr::E => Value::Array(vec![Value::String("e".into())]),
+        Expr::Distance(v) => Value::Array(vec![Value::String("distance".into()), v.clone()]),
+
+        // Color
+        Expr::Rgb(r, g, b) => Value::Array(vec![
+            Value::String("rgb".into()),
+            expr_to_value(r),
+            expr_to_value(g),
+            expr_to_value(b),
+        ]),
+        Expr::Rgba(r, g, b, a) => Value::Array(vec![
+            Value::String("rgba".into()),
+            expr_to_value(r),
+            expr_to_value(g),
+            expr_to_value(b),
+            expr_to_value(a),
+        ]),
+        Expr::ToRgba(inner) => unary_array("to-rgba", inner),
+
+        // Type operators
+        Expr::TypeOf(inner) => unary_array("typeof", inner),
+        Expr::ToString(inner) => unary_array("to-string", inner),
+        Expr::ToNumber(args) => variadic_array("to-number", args),
+        Expr::ToBoolean(inner) => unary_array("to-boolean", inner),
+        Expr::ToColor(args) => variadic_array("to-color", args),
+        Expr::NumberAssertion(args) => variadic_array("number", args),
+        Expr::StringAssertion(args) => variadic_array("string", args),
+        Expr::BooleanAssertion(args) => variadic_array("boolean", args),
+        Expr::ObjectAssertion(args) => variadic_array("object", args),
+        Expr::ArrayAssertion {
+            element_type,
+            length,
+            value,
+        } => {
+            let mut arr = vec![Value::String("array".into())];
+            if let Some(et) = element_type {
+                arr.push(Value::String(et.clone()));
+                if let Some(len) = length {
+                    arr.push(Value::Number((*len).into()));
+                }
+            }
+            arr.push(expr_to_value(value));
+            Value::Array(arr)
+        }
+        Expr::Collator(opts) => Value::Array(vec![Value::String("collator".into()), opts.clone()]),
+        Expr::Format(sections) => {
+            let mut arr = vec![Value::String("format".into())];
+            for (content, style) in sections {
+                arr.push(expr_to_value(content));
+                if let Some(s) = style {
+                    arr.push(s.clone());
+                }
+            }
+            Value::Array(arr)
+        }
+        Expr::Image(inner) => unary_array("image", inner),
+        Expr::NumberFormat { input, options } => Value::Array(vec![
+            Value::String("number-format".into()),
+            expr_to_value(input),
+            options.clone(),
+        ]),
+
+        // Feature data
+        Expr::FeatureState(inner) => unary_array("feature-state", inner),
+        Expr::GeometryType => Value::Array(vec![Value::String("geometry-type".into())]),
+        Expr::Id => Value::Array(vec![Value::String("id".into())]),
+        Expr::Properties => Value::Array(vec![Value::String("properties".into())]),
+        Expr::Accumulated => Value::Array(vec![Value::String("accumulated".into())]),
+        Expr::LineProgress => Value::Array(vec![Value::String("line-progress".into())]),
+
+        // Camera
+        Expr::Zoom => Value::Array(vec![Value::String("zoom".into())]),
+
+        // Heatmap
+        Expr::HeatmapDensity => Value::Array(vec![Value::String("heatmap-density".into())]),
+
+        // Color relief
+        Expr::Elevation => Value::Array(vec![Value::String("elevation".into())]),
+
+        // String
+        Expr::Upcase(inner) => unary_array("upcase", inner),
+        Expr::Downcase(inner) => unary_array("downcase", inner),
+        Expr::Concat(args) => variadic_array("concat", args),
+        Expr::IsSupportedScript(inner) => unary_array("is-supported-script", inner),
+        Expr::ResolvedLocale(inner) => unary_array("resolved-locale", inner),
+        Expr::Split(a, b) => binary_array("split", a, b),
+        Expr::Join(a, b) => binary_array("join", a, b),
+
+        // Unknown
+        Expr::Unknown { operator, args } => {
+            let mut arr = vec![Value::String(operator.clone())];
+            arr.extend(args.iter().cloned());
+            Value::Array(arr)
+        }
+    }
+}
+
+fn unary_array(op: &str, inner: &Expr) -> Value {
+    Value::Array(vec![Value::String(op.into()), expr_to_value(inner)])
+}
+
+fn binary_array(op: &str, a: &Expr, b: &Expr) -> Value {
+    Value::Array(vec![
+        Value::String(op.into()),
+        expr_to_value(a),
+        expr_to_value(b),
+    ])
+}
+
+fn variadic_array(op: &str, args: &[Expr]) -> Value {
+    let mut arr = vec![Value::String(op.into())];
+    for a in args {
+        arr.push(expr_to_value(a));
+    }
+    Value::Array(arr)
+}
+
+fn opt_object_array(op: &str, property: &Expr, object: Option<&Expr>) -> Value {
+    let mut arr = vec![Value::String(op.into()), expr_to_value(property)];
+    if let Some(obj) = object {
+        arr.push(expr_to_value(obj));
+    }
+    Value::Array(arr)
+}
+
+fn interp_to_array(
+    op: &str,
+    interpolation: &Interpolation,
+    input: &Expr,
+    stops: &[(Expr, Expr)],
+) -> Value {
+    let mut arr = vec![
+        Value::String(op.into()),
+        serde_json::to_value(interpolation).unwrap_or(Value::Null),
+        expr_to_value(input),
+    ];
+    for (inp, out) in stops {
+        arr.push(expr_to_value(inp));
+        arr.push(expr_to_value(out));
+    }
+    Value::Array(arr)
+}
+
+impl<'de> Deserialize<'de> for Expr {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // Only JSON arrays are valid top-level expressions.  Non-arrays
+        // produce an error so that `StyleValue<T>` can fall through to the
+        // `Function` or `Literal(T)` variant instead.
+        let v = Value::deserialize(d)?;
+        match v {
+            Value::Array(arr) => parse_expr_array(arr).map_err(de::Error::custom),
+            _ => Err(de::Error::custom("expression must be a JSON array")),
+        }
+    }
+}
+
+/// Parse an [`Expr`] from a [`Value`].
+///
+/// Arrays are interpreted as expressions; all other JSON values become
+/// [`Expr::Literal`].
+pub(crate) fn expr_from_value(v: Value) -> Result<Expr, String> {
+    match v {
+        Value::Array(arr) => parse_expr_array(arr),
+        other => Ok(Expr::Literal(other)),
+    }
+}
+
+fn box_expr(v: Value) -> Result<Box<Expr>, String> {
+    expr_from_value(v).map(Box::new)
+}
+
+/// Consume an argument from a positioned argument list, returning a descriptive
+/// error if the index is out of bounds.
+fn take_arg(args: &mut Vec<Value>, pos: usize, op: &str) -> Result<Value, String> {
+    if args.is_empty() {
+        Err(format!(
+            "expression \"{op}\": expected argument at position {pos} but got none"
+        ))
+    } else {
+        Ok(args.remove(0))
+    }
+}
+
+/// Parse `["operator", arg1, arg2, ...]` where `arr` is the full array
+/// (operator is `arr[0]`).
+fn parse_expr_array(mut arr: Vec<Value>) -> Result<Expr, String> {
+    if arr.is_empty() {
+        return Err("expression array is empty".into());
+    }
+
+    let op_val = arr.remove(0);
+    let op = match &op_val {
+        Value::String(s) => s.clone(),
+        _ => {
+            // Not a string operator → treat the whole original array as a literal.
+            let mut full = vec![op_val];
+            full.extend(arr);
+            return Ok(Expr::Literal(Value::Array(full)));
+        }
+    };
+    // `arr` now contains the arguments (op removed).
+    let mut args = arr;
+
+    match op.as_str() {
+        "let" => {
+            // ["let", name1, val1, ..., nameN, valN, body]
+            // Must have at least 3 elements: one binding pair + body.
+            if args.len() < 3 || args.len().is_multiple_of(2) {
+                return Err(format!(
+                    "expression \"let\": expected odd number of arguments ≥ 3, got {}",
+                    args.len()
+                ));
+            }
+            let body_val = args.pop().unwrap();
+            let body = box_expr(body_val)?;
+            let mut bindings = Vec::new();
+            while args.len() >= 2 {
+                let name = match args.remove(0) {
+                    Value::String(s) => s,
+                    other => {
+                        return Err(format!(
+                            "expression \"let\": binding name must be a string, got {other}"
+                        ))
+                    }
+                };
+                let val = box_expr(args.remove(0))?;
+                bindings.push((name, val));
+            }
+            Ok(Expr::Let { bindings, body })
+        }
+
+        "var" => {
+            let name = match take_arg(&mut args, 1, "var")? {
+                Value::String(s) => s,
+                other => {
+                    return Err(format!(
+                        "expression \"var\": name must be a string, got {other}"
+                    ))
+                }
+            };
+            Ok(Expr::Var(name))
+        }
+
+        "step" => {
+            // ["step", input, default_output, stop1_in, stop1_out, ...]
+            if args.len() < 2 {
+                return Err(format!(
+                    "expression \"step\": expected at least 2 arguments, got {}",
+                    args.len()
+                ));
+            }
+            let input = box_expr(args.remove(0))?;
+            let default_output = box_expr(args.remove(0))?;
+            let stops = parse_stop_pairs(&mut args, "step")?;
+            Ok(Expr::Step {
+                input,
+                default_output,
+                stops,
+            })
+        }
+
+        "interpolate" | "interpolate-hcl" | "interpolate-lab" => {
+            // ["interpolate", interp, input, stop1_in, stop1_out, ...]
+            if args.len() < 2 {
+                return Err(format!(
+                    "expression \"{op}\": expected at least 2 arguments, got {}",
+                    args.len()
+                ));
+            }
+            let interp_val = args.remove(0);
+            let interpolation = serde_json::from_value::<Interpolation>(interp_val)
+                .map_err(|e| format!("expression \"{op}\": bad interpolation: {e}"))?;
+            let input = box_expr(args.remove(0))?;
+            let stops = parse_stop_pairs(&mut args, &op)?;
+            match op.as_str() {
+                "interpolate" => Ok(Expr::Interpolate {
+                    interpolation,
+                    input,
+                    stops,
+                }),
+                "interpolate-hcl" => Ok(Expr::InterpolateHcl {
+                    interpolation,
+                    input,
+                    stops,
+                }),
+                _ => Ok(Expr::InterpolateLab {
+                    interpolation,
+                    input,
+                    stops,
+                }),
+            }
+        }
+
+        "get" => {
+            let property = box_expr(take_arg(&mut args, 1, "get")?)?;
+            let object = if args.is_empty() {
+                None
+            } else {
+                Some(box_expr(args.remove(0))?)
+            };
+            Ok(Expr::Get { property, object })
+        }
+
+        "has" => {
+            let property = box_expr(take_arg(&mut args, 1, "has")?)?;
+            let object = if args.is_empty() {
+                None
+            } else {
+                Some(box_expr(args.remove(0))?)
+            };
+            Ok(Expr::Has { property, object })
+        }
+
+        "at" => {
+            let index = box_expr(take_arg(&mut args, 1, "at")?)?;
+            let array = box_expr(take_arg(&mut args, 2, "at")?)?;
+            Ok(Expr::At { index, array })
+        }
+
+        "in" => {
+            let item = box_expr(take_arg(&mut args, 1, "in")?)?;
+            let array_or_string = box_expr(take_arg(&mut args, 2, "in")?)?;
+            Ok(Expr::In {
+                item,
+                array_or_string,
+            })
+        }
+
+        "index-of" => {
+            let item = box_expr(take_arg(&mut args, 1, "index-of")?)?;
+            let array_or_string = box_expr(take_arg(&mut args, 2, "index-of")?)?;
+            let from_index = if args.is_empty() {
+                None
+            } else {
+                Some(box_expr(args.remove(0))?)
+            };
+            Ok(Expr::IndexOf {
+                item,
+                array_or_string,
+                from_index,
+            })
+        }
+
+        "slice" => {
+            let array_or_string = box_expr(take_arg(&mut args, 1, "slice")?)?;
+            let start = box_expr(take_arg(&mut args, 2, "slice")?)?;
+            let end = if args.is_empty() {
+                None
+            } else {
+                Some(box_expr(args.remove(0))?)
+            };
+            Ok(Expr::Slice {
+                array_or_string,
+                start,
+                end,
+            })
+        }
+
+        "length" => Ok(Expr::Length(box_expr(take_arg(&mut args, 1, "length")?)?)),
+
+        "global-state" => Ok(Expr::GlobalState(box_expr(take_arg(
+            &mut args,
+            1,
+            "global-state",
+        )?)?)),
+
+        "case" => {
+            // ["case", cond1, out1, ..., condN, outN, fallback]
+            if args.len() < 3 || args.len().is_multiple_of(2) {
+                return Err(format!(
+                    "expression \"case\": expected odd number of arguments ≥ 3, got {}",
+                    args.len()
+                ));
+            }
+            let fallback_val = args.pop().unwrap();
+            let fallback = box_expr(fallback_val)?;
+            let mut branches = Vec::new();
+            while args.len() >= 2 {
+                let cond = box_expr(args.remove(0))?;
+                let out = box_expr(args.remove(0))?;
+                branches.push((cond, out));
+            }
+            Ok(Expr::Case { branches, fallback })
+        }
+
+        "match" => {
+            // ["match", input, label1, out1, ..., labelN, outN, fallback]
+            if args.len() < 4 || !args.len().is_multiple_of(2) {
+                return Err(format!(
+                    "expression \"match\": expected even number of arguments ≥ 4, got {}",
+                    args.len()
+                ));
+            }
+            let input = box_expr(args.remove(0))?;
+            let fallback_val = args.pop().unwrap();
+            let fallback = box_expr(fallback_val)?;
+            let mut branches = Vec::new();
+            while args.len() >= 2 {
+                let label_val = args.remove(0);
+                let labels = match label_val {
+                    Value::Array(arr) => arr,
+                    scalar => vec![scalar],
+                };
+                let out = box_expr(args.remove(0))?;
+                branches.push((labels, out));
+            }
+            Ok(Expr::Match {
+                input,
+                branches,
+                fallback,
+            })
+        }
+
+        "coalesce" => Ok(Expr::Coalesce(parse_variadic(args)?)),
+        "all" => Ok(Expr::All(parse_variadic(args)?)),
+        "any" => Ok(Expr::Any(parse_variadic(args)?)),
+
+        "!" => Ok(Expr::Not(box_expr(take_arg(&mut args, 1, "!")?)?)),
+
+        "==" => Ok(Expr::Eq(
+            box_expr(take_arg(&mut args, 1, "==")?)?,
+            box_expr(take_arg(&mut args, 2, "==")?)?,
+        )),
+        "!=" => Ok(Expr::Ne(
+            box_expr(take_arg(&mut args, 1, "!=")?)?,
+            box_expr(take_arg(&mut args, 2, "!=")?)?,
+        )),
+        ">" => Ok(Expr::Gt(
+            box_expr(take_arg(&mut args, 1, ">")?)?,
+            box_expr(take_arg(&mut args, 2, ">")?)?,
+        )),
+        ">=" => Ok(Expr::Gte(
+            box_expr(take_arg(&mut args, 1, ">=")?)?,
+            box_expr(take_arg(&mut args, 2, ">=")?)?,
+        )),
+        "<" => Ok(Expr::Lt(
+            box_expr(take_arg(&mut args, 1, "<")?)?,
+            box_expr(take_arg(&mut args, 2, "<")?)?,
+        )),
+        "<=" => Ok(Expr::Lte(
+            box_expr(take_arg(&mut args, 1, "<=")?)?,
+            box_expr(take_arg(&mut args, 2, "<=")?)?,
+        )),
+
+        "within" => Ok(Expr::Within(take_arg(&mut args, 1, "within")?)),
+
+        "+" => Ok(Expr::Add(parse_variadic(args)?)),
+        "*" => Ok(Expr::Mul(parse_variadic(args)?)),
+
+        "-" => {
+            let a = box_expr(take_arg(&mut args, 1, "-")?)?;
+            let b = if args.is_empty() {
+                None
+            } else {
+                Some(box_expr(args.remove(0))?)
+            };
+            Ok(Expr::Sub(a, b))
+        }
+
+        "/" => Ok(Expr::Div(
+            box_expr(take_arg(&mut args, 1, "/")?)?,
+            box_expr(take_arg(&mut args, 2, "/")?)?,
+        )),
+        "%" => Ok(Expr::Mod(
+            box_expr(take_arg(&mut args, 1, "%")?)?,
+            box_expr(take_arg(&mut args, 2, "%")?)?,
+        )),
+        "^" => Ok(Expr::Pow(
+            box_expr(take_arg(&mut args, 1, "^")?)?,
+            box_expr(take_arg(&mut args, 2, "^")?)?,
+        )),
+
+        "sqrt" => Ok(Expr::Sqrt(box_expr(take_arg(&mut args, 1, "sqrt")?)?)),
+        "abs" => Ok(Expr::Abs(box_expr(take_arg(&mut args, 1, "abs")?)?)),
+        "ceil" => Ok(Expr::Ceil(box_expr(take_arg(&mut args, 1, "ceil")?)?)),
+        "floor" => Ok(Expr::Floor(box_expr(take_arg(&mut args, 1, "floor")?)?)),
+        "round" => Ok(Expr::Round(box_expr(take_arg(&mut args, 1, "round")?)?)),
+
+        "min" => Ok(Expr::Min(parse_variadic(args)?)),
+        "max" => Ok(Expr::Max(parse_variadic(args)?)),
+
+        "log2" => Ok(Expr::Log2(box_expr(take_arg(&mut args, 1, "log2")?)?)),
+        "log10" => Ok(Expr::Log10(box_expr(take_arg(&mut args, 1, "log10")?)?)),
+        "ln" => Ok(Expr::Ln(box_expr(take_arg(&mut args, 1, "ln")?)?)),
+        "sin" => Ok(Expr::Sin(box_expr(take_arg(&mut args, 1, "sin")?)?)),
+        "cos" => Ok(Expr::Cos(box_expr(take_arg(&mut args, 1, "cos")?)?)),
+        "tan" => Ok(Expr::Tan(box_expr(take_arg(&mut args, 1, "tan")?)?)),
+        "asin" => Ok(Expr::Asin(box_expr(take_arg(&mut args, 1, "asin")?)?)),
+        "acos" => Ok(Expr::Acos(box_expr(take_arg(&mut args, 1, "acos")?)?)),
+        "atan" => Ok(Expr::Atan(box_expr(take_arg(&mut args, 1, "atan")?)?)),
+
+        "ln2" => Ok(Expr::Ln2),
+        "pi" => Ok(Expr::Pi),
+        "e" => Ok(Expr::E),
+
+        "distance" => Ok(Expr::Distance(take_arg(&mut args, 1, "distance")?)),
+
+        "rgb" => Ok(Expr::Rgb(
+            box_expr(take_arg(&mut args, 1, "rgb")?)?,
+            box_expr(take_arg(&mut args, 2, "rgb")?)?,
+            box_expr(take_arg(&mut args, 3, "rgb")?)?,
+        )),
+        "rgba" => Ok(Expr::Rgba(
+            box_expr(take_arg(&mut args, 1, "rgba")?)?,
+            box_expr(take_arg(&mut args, 2, "rgba")?)?,
+            box_expr(take_arg(&mut args, 3, "rgba")?)?,
+            box_expr(take_arg(&mut args, 4, "rgba")?)?,
+        )),
+        "to-rgba" => Ok(Expr::ToRgba(box_expr(take_arg(&mut args, 1, "to-rgba")?)?)),
+
+        "literal" => Ok(Expr::LiteralExpr(take_arg(&mut args, 1, "literal")?)),
+        "typeof" => Ok(Expr::TypeOf(box_expr(take_arg(&mut args, 1, "typeof")?)?)),
+        "to-string" => Ok(Expr::ToString(box_expr(take_arg(
+            &mut args,
+            1,
+            "to-string",
+        )?)?)),
+        "to-number" => Ok(Expr::ToNumber(parse_variadic(args)?)),
+        "to-boolean" => Ok(Expr::ToBoolean(box_expr(take_arg(
+            &mut args,
+            1,
+            "to-boolean",
+        )?)?)),
+        "to-color" => Ok(Expr::ToColor(parse_variadic(args)?)),
+
+        "number" => Ok(Expr::NumberAssertion(parse_variadic(args)?)),
+        "string" => Ok(Expr::StringAssertion(parse_variadic(args)?)),
+        "boolean" => Ok(Expr::BooleanAssertion(parse_variadic(args)?)),
+        "object" => Ok(Expr::ObjectAssertion(parse_variadic(args)?)),
+
+        "array" => {
+            // ["array", value] | ["array", type, value] | ["array", type, len, value]
+            match args.len() {
+                1 => {
+                    let value = box_expr(args.remove(0))?;
+                    Ok(Expr::ArrayAssertion {
+                        element_type: None,
+                        length: None,
+                        value,
+                    })
+                }
+                2 => {
+                    let element_type = match args.remove(0) {
+                        Value::String(s) => Some(s),
+                        _ => None,
+                    };
+                    let value = box_expr(args.remove(0))?;
+                    Ok(Expr::ArrayAssertion {
+                        element_type,
+                        length: None,
+                        value,
+                    })
+                }
+                3 => {
+                    let element_type = match args.remove(0) {
+                        Value::String(s) => Some(s),
+                        _ => None,
+                    };
+                    let length = args.remove(0).as_u64();
+                    let value = box_expr(args.remove(0))?;
+                    Ok(Expr::ArrayAssertion {
+                        element_type,
+                        length,
+                        value,
+                    })
+                }
+                n => Err(format!(
+                    "expression \"array\": expected 1–3 arguments, got {n}"
+                )),
+            }
+        }
+
+        "collator" => Ok(Expr::Collator(take_arg(&mut args, 1, "collator")?)),
+
+        "format" => {
+            // ["format", input_1, style_1?, input_2, style_2?, ...]
+            // style overrides are objects; inputs are expressions
+            let mut sections = Vec::new();
+            while !args.is_empty() {
+                let content = box_expr(args.remove(0))?;
+                let style = if args.first().map(|v| v.is_object()).unwrap_or(false) {
+                    Some(args.remove(0))
+                } else {
+                    None
+                };
+                sections.push((content, style));
+            }
+            Ok(Expr::Format(sections))
+        }
+
+        "image" => Ok(Expr::Image(box_expr(take_arg(&mut args, 1, "image")?)?)),
+
+        "number-format" => {
+            let input = box_expr(take_arg(&mut args, 1, "number-format")?)?;
+            let options = take_arg(&mut args, 2, "number-format")?;
+            Ok(Expr::NumberFormat { input, options })
+        }
+
+        "feature-state" => Ok(Expr::FeatureState(box_expr(take_arg(
+            &mut args,
+            1,
+            "feature-state",
+        )?)?)),
+        "geometry-type" => Ok(Expr::GeometryType),
+        "id" => Ok(Expr::Id),
+        "properties" => Ok(Expr::Properties),
+        "accumulated" => Ok(Expr::Accumulated),
+        "line-progress" => Ok(Expr::LineProgress),
+
+        "zoom" => Ok(Expr::Zoom),
+
+        "heatmap-density" => Ok(Expr::HeatmapDensity),
+
+        "elevation" => Ok(Expr::Elevation),
+
+        "upcase" => Ok(Expr::Upcase(box_expr(take_arg(&mut args, 1, "upcase")?)?)),
+        "downcase" => Ok(Expr::Downcase(box_expr(take_arg(
+            &mut args, 1, "downcase",
+        )?)?)),
+        "concat" => Ok(Expr::Concat(parse_variadic(args)?)),
+        "is-supported-script" => Ok(Expr::IsSupportedScript(box_expr(take_arg(
+            &mut args,
+            1,
+            "is-supported-script",
+        )?)?)),
+        "resolved-locale" => Ok(Expr::ResolvedLocale(box_expr(take_arg(
+            &mut args,
+            1,
+            "resolved-locale",
+        )?)?)),
+        "split" => Ok(Expr::Split(
+            box_expr(take_arg(&mut args, 1, "split")?)?,
+            box_expr(take_arg(&mut args, 2, "split")?)?,
+        )),
+        "join" => Ok(Expr::Join(
+            box_expr(take_arg(&mut args, 1, "join")?)?,
+            box_expr(take_arg(&mut args, 2, "join")?)?,
+        )),
+
+        other => Ok(Expr::Unknown {
+            operator: other.to_owned(),
+            args,
+        }),
+    }
+}
+
+/// Parse pairs of `(input, output)` from a flat argument list, used by
+/// `step` and the `interpolate` family.
+fn parse_stop_pairs(args: &mut Vec<Value>, op: &str) -> Result<Vec<(Expr, Expr)>, String> {
+    if !args.len().is_multiple_of(2) {
+        return Err(format!(
+            "expression \"{op}\": stop arguments must come in (input, output) pairs, got {} args",
+            args.len()
+        ));
+    }
+    let mut stops = Vec::new();
+    while args.len() >= 2 {
+        let input = expr_from_value(args.remove(0))?;
+        let output = expr_from_value(args.remove(0))?;
+        stops.push((input, output));
+    }
+    Ok(stops)
+}
+
+/// Parse a variable-length list of expression arguments.
+fn parse_variadic(args: Vec<Value>) -> Result<Vec<Expr>, String> {
+    args.into_iter().map(expr_from_value).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn parse(v: serde_json::Value) -> Expr {
+        serde_json::from_value(v).unwrap()
+    }
+
+    #[test]
+    fn interpolation_linear() {
+        let i: Interpolation = serde_json::from_value(json!(["linear"])).unwrap();
+        assert_eq!(i, Interpolation::Linear);
+    }
+
+    #[test]
+    fn interpolation_exponential() {
+        let i: Interpolation = serde_json::from_value(json!(["exponential", 1.5])).unwrap();
+        assert_eq!(i, Interpolation::Exponential { base: 1.5 });
+    }
+
+    #[test]
+    fn interpolation_cubic_bezier() {
+        let i: Interpolation =
+            serde_json::from_value(json!(["cubic-bezier", 0.0, 0.0, 1.0, 1.0])).unwrap();
+        assert_eq!(
+            i,
+            Interpolation::CubicBezier {
+                x1: 0.0,
+                y1: 0.0,
+                x2: 1.0,
+                y2: 1.0
+            }
+        );
+    }
+
+    #[test]
+    fn literal_number_as_arg() {
+        // Numbers appear as Literal args inside expressions (e.g. stop inputs)
+        let e = parse(json!(["step", ["zoom"], 0, 5, 1]));
+        match e {
+            Expr::Step { default_output, .. } => {
+                assert!(matches!(*default_output, Expr::Literal(Value::Number(_))));
+            }
+            other => panic!("expected Step, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn literal_string_as_arg() {
+        // Strings appear as Literal args inside expressions (e.g. get property)
+        let e = parse(json!(["get", "name"]));
+        match e {
+            Expr::Get { property, .. } => {
+                assert!(matches!(*property, Expr::Literal(Value::String(_))));
+            }
+            other => panic!("expected Get, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn literal_bool_as_arg() {
+        // Booleans appear as Literal args inside expressions
+        let e = parse(json!(["!", false]));
+        assert!(matches!(e, Expr::Not(inner) if matches!(*inner, Expr::Literal(Value::Bool(_)))));
+    }
+
+    #[test]
+    fn zoom() {
+        assert_eq!(parse(json!(["zoom"])), Expr::Zoom);
+    }
+
+    #[test]
+    fn geometry_type() {
+        assert_eq!(parse(json!(["geometry-type"])), Expr::GeometryType);
+    }
+
+    #[test]
+    fn id_expr() {
+        assert_eq!(parse(json!(["id"])), Expr::Id);
+    }
+
+    #[test]
+    fn heatmap_density() {
+        assert_eq!(parse(json!(["heatmap-density"])), Expr::HeatmapDensity);
+    }
+
+    #[test]
+    fn get_no_object() {
+        let e = parse(json!(["get", "name"]));
+        assert!(matches!(e, Expr::Get { object: None, .. }));
+    }
+
+    #[test]
+    fn get_with_object() {
+        let e = parse(json!(["get", "name", ["properties"]]));
+        assert!(matches!(
+            e,
+            Expr::Get {
+                object: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn has_expr() {
+        let e = parse(json!(["has", "population"]));
+        assert!(matches!(e, Expr::Has { object: None, .. }));
+    }
+
+    #[test]
+    fn step_expr() {
+        let e = parse(json!(["step", ["zoom"], 0.5, 12, 1.0, 15, 2.0]));
+        match e {
+            Expr::Step { stops, .. } => assert_eq!(stops.len(), 2),
+            other => panic!("expected Step, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpolate_linear_zoom() {
+        let e = parse(json!([
+            "interpolate",
+            ["linear"],
+            ["zoom"],
+            5,
+            1.0,
+            10,
+            4.0
+        ]));
+        match e {
+            Expr::Interpolate {
+                interpolation,
+                stops,
+                ..
+            } => {
+                assert_eq!(interpolation, Interpolation::Linear);
+                assert_eq!(stops.len(), 2);
+            }
+            other => panic!("expected Interpolate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpolate_exponential() {
+        let e = parse(json!([
+            "interpolate",
+            ["exponential", 1.4],
+            ["zoom"],
+            5,
+            1.0,
+            10,
+            4.0
+        ]));
+        match e {
+            Expr::Interpolate { interpolation, .. } => {
+                assert_eq!(interpolation, Interpolation::Exponential { base: 1.4 });
+            }
+            other => panic!("expected Interpolate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpolate_hcl() {
+        let e = parse(json!([
+            "interpolate-hcl",
+            ["linear"],
+            ["zoom"],
+            0,
+            "#f00",
+            10,
+            "#00f"
+        ]));
+        assert!(matches!(e, Expr::InterpolateHcl { .. }));
+    }
+
+    #[test]
+    fn add_expr() {
+        let e = parse(json!(["+", 1, 2, 3]));
+        match e {
+            Expr::Add(args) => assert_eq!(args.len(), 3),
+            other => panic!("expected Add, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sub_unary() {
+        let e = parse(json!(["-", ["get", "val"]]));
+        assert!(matches!(e, Expr::Sub(_, None)));
+    }
+
+    #[test]
+    fn sub_binary() {
+        let e = parse(json!(["-", 10, 3]));
+        assert!(matches!(e, Expr::Sub(_, Some(_))));
+    }
+
+    #[test]
+    fn math_constants() {
+        assert_eq!(parse(json!(["ln2"])), Expr::Ln2);
+        assert_eq!(parse(json!(["pi"])), Expr::Pi);
+        assert_eq!(parse(json!(["e"])), Expr::E);
+    }
+
+    #[test]
+    fn case_expr() {
+        let e = parse(json!(["case", ["has", "name"], "yes", "no"]));
+        match e {
+            Expr::Case { branches, .. } => assert_eq!(branches.len(), 1),
+            other => panic!("expected Case, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn match_expr_scalar_labels() {
+        let e = parse(json!([
+            "match",
+            ["get", "class"],
+            "residential",
+            "#f00",
+            "commercial",
+            "#0f0",
+            "#000"
+        ]));
+        match e {
+            Expr::Match { branches, .. } => {
+                assert_eq!(branches.len(), 2);
+                assert_eq!(branches[0].0, vec![json!("residential")]);
+            }
+            other => panic!("expected Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn match_expr_array_labels() {
+        let e = parse(json!(["match", ["get", "n"], [1, 2], "low", "other"]));
+        match e {
+            Expr::Match { branches, .. } => {
+                assert_eq!(branches[0].0, vec![json!(1), json!(2)]);
+            }
+            other => panic!("expected Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_any_not() {
+        assert!(matches!(parse(json!(["all", true, false])), Expr::All(_)));
+        assert!(matches!(parse(json!(["any", true, false])), Expr::Any(_)));
+        assert!(matches!(parse(json!(["!", true])), Expr::Not(_)));
+    }
+
+    #[test]
+    fn comparison_ops() {
+        assert!(matches!(parse(json!(["==", 1, 1])), Expr::Eq(_, _)));
+        assert!(matches!(parse(json!(["!=", 1, 2])), Expr::Ne(_, _)));
+        assert!(matches!(parse(json!([">", 2, 1])), Expr::Gt(_, _)));
+        assert!(matches!(parse(json!([">=", 2, 2])), Expr::Gte(_, _)));
+        assert!(matches!(parse(json!(["<", 1, 2])), Expr::Lt(_, _)));
+        assert!(matches!(parse(json!(["<=", 1, 2])), Expr::Lte(_, _)));
+    }
+
+    #[test]
+    fn literal_expr() {
+        let e = parse(json!(["literal", [1, 2, 3]]));
+        assert!(matches!(e, Expr::LiteralExpr(Value::Array(_))));
+    }
+
+    #[test]
+    fn array_assertion_bare() {
+        let e = parse(json!(["array", ["get", "coords"]]));
+        assert!(matches!(
+            e,
+            Expr::ArrayAssertion {
+                element_type: None,
+                length: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn array_assertion_typed() {
+        let e = parse(json!(["array", "number", ["get", "coords"]]));
+        match e {
+            Expr::ArrayAssertion {
+                element_type,
+                length,
+                ..
+            } => {
+                assert_eq!(element_type.as_deref(), Some("number"));
+                assert!(length.is_none());
+            }
+            other => panic!("expected ArrayAssertion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn array_assertion_typed_and_length() {
+        let e = parse(json!(["array", "string", 3, ["literal", ["a", "b", "c"]]]));
+        match e {
+            Expr::ArrayAssertion {
+                element_type,
+                length,
+                ..
+            } => {
+                assert_eq!(element_type.as_deref(), Some("string"));
+                assert_eq!(length, Some(3));
+            }
+            other => panic!("expected ArrayAssertion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn concat_expr() {
+        let e = parse(json!(["concat", "hello", " ", "world"]));
+        match e {
+            Expr::Concat(args) => assert_eq!(args.len(), 3),
+            other => panic!("expected Concat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn upcase_downcase() {
+        assert!(matches!(parse(json!(["upcase", "hi"])), Expr::Upcase(_)));
+        assert!(matches!(
+            parse(json!(["downcase", "HI"])),
+            Expr::Downcase(_)
+        ));
+    }
+
+    #[test]
+    fn let_var_binding() {
+        let e = parse(json!(["let", "x", 42, ["var", "x"]]));
+        match e {
+            Expr::Let { bindings, body } => {
+                assert_eq!(bindings.len(), 1);
+                assert_eq!(bindings[0].0, "x");
+                assert!(matches!(*body, Expr::Var(ref s) if s == "x"));
+            }
+            other => panic!("expected Let, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_operator() {
+        let e = parse(json!(["future-operator", 1, 2]));
+        match e {
+            Expr::Unknown { operator, args } => {
+                assert_eq!(operator, "future-operator");
+                assert_eq!(args.len(), 2);
+            }
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_get_in_comparison() {
+        let e = parse(json!([">=", ["get", "mag"], 4]));
+        match e {
+            Expr::Gte(left, right) => {
+                assert!(matches!(*left, Expr::Get { .. }));
+                assert!(matches!(*right, Expr::Literal(_)));
+            }
+            other => panic!("expected Gte, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rgb_expr() {
+        let e = parse(json!(["rgb", 255, 0, 128]));
+        assert!(matches!(e, Expr::Rgb(_, _, _)));
+    }
+
+    #[test]
+    fn feature_state_expr() {
+        let e = parse(json!(["feature-state", "hover"]));
+        assert!(matches!(e, Expr::FeatureState(_)));
+    }
+
+    #[test]
+    fn format_expr() {
+        let e = parse(json!(["format", ["get", "name"], {"font-scale": 0.8}, "\n", {}]));
+        match e {
+            Expr::Format(sections) => {
+                assert_eq!(sections.len(), 2);
+                assert!(sections[0].1.is_some()); // has style override
+                assert!(sections[1].1.is_some()); // has empty style override
+            }
+            other => panic!("expected Format, got {other:?}"),
+        }
+    }
+}

--- a/galileo-maplibre/src/style/helpers.rs
+++ b/galileo-maplibre/src/style/helpers.rs
@@ -1,0 +1,23 @@
+//! Shared deserialisation helpers used across style submodules.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Deserialise an `f64` from a JSON [`Value`], falling back to `fallback`
+/// (and logging a warning) when the value is invalid or null.
+pub(super) fn deserialize_f64_with_fallback<'de, D>(
+    deserializer: D,
+    fallback: f64,
+    field_name: &str,
+) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(fallback),
+        v => serde_json::from_value::<f64>(v.clone()).or_else(|err| {
+            log::warn!("Invalid {field_name} value {v}: {err}; using default ({fallback})");
+            Ok(fallback)
+        }),
+    }
+}

--- a/galileo-maplibre/src/style/layer/background.rs
+++ b/galileo-maplibre/src/style/layer/background.rs
@@ -1,0 +1,56 @@
+//! Background layer types.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::common::{
+    default_layer_maxzoom, default_layer_minzoom, deserialize_maxzoom, deserialize_minzoom,
+    CommonLayout,
+};
+
+/// Paint properties for a background layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct BackgroundPaint {
+    /// The colour with which the background will be drawn.
+    #[serde(rename = "background-color")]
+    pub background_color: Option<Value>,
+    /// The opacity at which the background will be drawn.
+    #[serde(rename = "background-opacity")]
+    pub background_opacity: Option<Value>,
+    /// Name of image in sprite to use for drawing an image background.
+    #[serde(rename = "background-pattern")]
+    pub background_pattern: Option<Value>,
+    /// Controls the intensity of light emitted on the source features.
+    #[serde(rename = "background-emissive-strength")]
+    pub background_emissive_strength: Option<Value>,
+}
+
+/// Layout properties for a background layer (visibility only).
+pub type BackgroundLayout = CommonLayout;
+
+/// A background layer fills the map with a single colour or pattern.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct BackgroundLayer {
+    /// Unique layer identifier.
+    pub id: String,
+    /// Arbitrary properties useful to track with the layer, but do not influence rendering.
+    pub metadata: Option<Value>,
+    /// The minimum zoom level for the layer (inclusive).
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+    /// The maximum zoom level for the layer (exclusive).
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+    /// Layout properties for this layer.
+    #[serde(default)]
+    pub layout: BackgroundLayout,
+    /// Paint properties for this layer.
+    #[serde(default)]
+    pub paint: BackgroundPaint,
+}

--- a/galileo-maplibre/src/style/layer/common.rs
+++ b/galileo-maplibre/src/style/layer/common.rs
@@ -1,0 +1,65 @@
+//! Shared types and deserialisation helpers used by all layer submodules.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::super::helpers::deserialize_f64_with_fallback;
+
+pub(super) const DEFAULT_MINZOOM: f64 = 0.0;
+pub(super) const DEFAULT_MAXZOOM: f64 = 24.0;
+
+pub(super) fn default_layer_minzoom() -> f64 {
+    DEFAULT_MINZOOM
+}
+
+pub(super) fn default_layer_maxzoom() -> f64 {
+    DEFAULT_MAXZOOM
+}
+
+pub(super) fn deserialize_minzoom<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_with_fallback(deserializer, DEFAULT_MINZOOM, "minzoom")
+}
+
+pub(super) fn deserialize_maxzoom<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_with_fallback(deserializer, DEFAULT_MAXZOOM, "maxzoom")
+}
+
+pub(super) fn deserialize_visibility_or_default<'de, D>(
+    deserializer: D,
+) -> Result<Visibility, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(Visibility::default()),
+        v => serde_json::from_value::<Visibility>(v.clone()).or_else(|err| {
+            log::warn!("Invalid visibility {v}: {err}; using default");
+            Ok(Visibility::default())
+        }),
+    }
+}
+
+/// Whether a layer is shown or hidden.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Visibility {
+    /// The layer is shown (default).
+    #[default]
+    Visible,
+    /// The layer is hidden.
+    None,
+}
+
+/// Layout properties shared by all layer types that have only a `visibility` field.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct CommonLayout {
+    /// Whether this layer is displayed.
+    #[serde(default, deserialize_with = "deserialize_visibility_or_default")]
+    pub visibility: Visibility,
+}

--- a/galileo-maplibre/src/style/layer/fill.rs
+++ b/galileo-maplibre/src/style/layer/fill.rs
@@ -1,0 +1,221 @@
+//! Fill and fill-extrusion layer types.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::common::{
+    default_layer_maxzoom, default_layer_minzoom, deserialize_maxzoom, deserialize_minzoom,
+    CommonLayout,
+};
+
+/// Paint properties for a `fill` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct FillPaint {
+    /// Whether or not the fill should be antialiased. Supports expressions.
+    #[serde(rename = "fill-antialias", skip_serializing_if = "Option::is_none")]
+    pub fill_antialias: Option<Value>,
+
+    /// Fill colour. Supports expressions.
+    #[serde(rename = "fill-color", skip_serializing_if = "Option::is_none")]
+    pub fill_color: Option<Value>,
+
+    /// Outline colour. Supports expressions.
+    #[serde(rename = "fill-outline-color", skip_serializing_if = "Option::is_none")]
+    pub fill_outline_color: Option<Value>,
+
+    /// Opacity of the entire fill layer. Supports expressions.
+    #[serde(rename = "fill-opacity", skip_serializing_if = "Option::is_none")]
+    pub fill_opacity: Option<Value>,
+
+    /// Name of image in sprite to use for drawing the fill pattern.
+    #[serde(rename = "fill-pattern", skip_serializing_if = "Option::is_none")]
+    pub fill_pattern: Option<Value>,
+
+    /// Translation of the fill pixels. Supports expressions.
+    #[serde(rename = "fill-translate", skip_serializing_if = "Option::is_none")]
+    pub fill_translate: Option<Value>,
+
+    /// Control whether the translation is relative to the map or viewport.
+    #[serde(
+        rename = "fill-translate-anchor",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_translate_anchor: Option<Value>,
+
+    /// Emission strength of the fill colour.
+    #[serde(
+        rename = "fill-emissive-strength",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_emissive_strength: Option<Value>,
+}
+
+/// Layout properties for a `fill` layer (visibility only).
+pub type FillLayout = CommonLayout;
+
+/// A `fill` layer draws filled polygons.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct FillLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Source to use for this layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+
+    /// Layer within the source to use.
+    #[serde(rename = "source-layer", skip_serializing_if = "Option::is_none")]
+    pub source_layer: Option<String>,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Minimum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+
+    /// Maximum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Filter expression to select features from the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<Value>,
+
+    /// Layout properties.
+    #[serde(default)]
+    pub layout: FillLayout,
+
+    /// Paint properties.
+    #[serde(default)]
+    pub paint: FillPaint,
+}
+
+/// Paint properties for a `fill-extrusion` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct FillExtrusionPaint {
+    /// Base height of the extrusion. Supports expressions.
+    #[serde(
+        rename = "fill-extrusion-base",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_extrusion_base: Option<Value>,
+
+    /// Fill colour of the extrusion. Supports expressions.
+    #[serde(
+        rename = "fill-extrusion-color",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_extrusion_color: Option<Value>,
+
+    /// Height of the extrusion. Supports expressions.
+    #[serde(
+        rename = "fill-extrusion-height",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_extrusion_height: Option<Value>,
+
+    /// Opacity of the extrusion. Supports expressions.
+    #[serde(
+        rename = "fill-extrusion-opacity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_extrusion_opacity: Option<Value>,
+
+    /// Name of image in sprite for drawing the extrusion pattern.
+    #[serde(
+        rename = "fill-extrusion-pattern",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_extrusion_pattern: Option<Value>,
+
+    /// Translation offset of the extrusion. Supports expressions.
+    #[serde(
+        rename = "fill-extrusion-translate",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_extrusion_translate: Option<Value>,
+
+    /// Control whether the translation is relative to map or viewport.
+    #[serde(
+        rename = "fill-extrusion-translate-anchor",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_extrusion_translate_anchor: Option<Value>,
+
+    /// Whether to apply a floor-level shadow.
+    #[serde(
+        rename = "fill-extrusion-flood-light-color",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_extrusion_flood_light_color: Option<Value>,
+
+    /// Intensity of the flood-light effect.
+    #[serde(
+        rename = "fill-extrusion-flood-light-intensity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_extrusion_flood_light_intensity: Option<Value>,
+
+    /// Emission strength of the fill-extrusion colour.
+    #[serde(
+        rename = "fill-extrusion-emissive-strength",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_extrusion_emissive_strength: Option<Value>,
+}
+
+/// Layout properties for a `fill-extrusion` layer (visibility only).
+pub type FillExtrusionLayout = CommonLayout;
+
+/// A `fill-extrusion` layer draws extruded (3D) polygons.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct FillExtrusionLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Source to use for this layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+
+    /// Layer within the source to use.
+    #[serde(rename = "source-layer", skip_serializing_if = "Option::is_none")]
+    pub source_layer: Option<String>,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Minimum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+
+    /// Maximum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Filter expression to select features from the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<Value>,
+
+    /// Layout properties.
+    #[serde(default)]
+    pub layout: FillExtrusionLayout,
+
+    /// Paint properties.
+    #[serde(default)]
+    pub paint: FillExtrusionPaint,
+}

--- a/galileo-maplibre/src/style/layer/line.rs
+++ b/galileo-maplibre/src/style/layer/line.rs
@@ -1,0 +1,141 @@
+//! Line layer types.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::common::{
+    default_layer_maxzoom, default_layer_minzoom, deserialize_maxzoom, deserialize_minzoom,
+    deserialize_visibility_or_default, Visibility,
+};
+
+/// Paint properties for a `line` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct LinePaint {
+    /// Line stroke colour. Supports expressions.
+    #[serde(rename = "line-color", skip_serializing_if = "Option::is_none")]
+    pub line_color: Option<Value>,
+
+    /// Line stroke opacity. Supports expressions.
+    #[serde(rename = "line-opacity", skip_serializing_if = "Option::is_none")]
+    pub line_opacity: Option<Value>,
+
+    /// Line stroke width in pixels. Supports expressions.
+    #[serde(rename = "line-width", skip_serializing_if = "Option::is_none")]
+    pub line_width: Option<Value>,
+
+    /// Line blur. Supports expressions.
+    #[serde(rename = "line-blur", skip_serializing_if = "Option::is_none")]
+    pub line_blur: Option<Value>,
+
+    /// Dash pattern for the line. Supports expressions.
+    #[serde(rename = "line-dasharray", skip_serializing_if = "Option::is_none")]
+    pub line_dasharray: Option<Value>,
+
+    /// Gap width for a casing effect. Supports expressions.
+    #[serde(rename = "line-gap-width", skip_serializing_if = "Option::is_none")]
+    pub line_gap_width: Option<Value>,
+
+    /// A gradient used to color a line feature.
+    #[serde(rename = "line-gradient", skip_serializing_if = "Option::is_none")]
+    pub line_gradient: Option<Value>,
+
+    /// Name of image in sprite to use for drawing line pattern.
+    #[serde(rename = "line-pattern", skip_serializing_if = "Option::is_none")]
+    pub line_pattern: Option<Value>,
+
+    /// Translation of the line pixels. Supports expressions.
+    #[serde(rename = "line-translate", skip_serializing_if = "Option::is_none")]
+    pub line_translate: Option<Value>,
+
+    /// Control whether the translation is relative to the map or viewport.
+    #[serde(
+        rename = "line-translate-anchor",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub line_translate_anchor: Option<Value>,
+
+    /// Emission strength of the line colour.
+    #[serde(
+        rename = "line-emissive-strength",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub line_emissive_strength: Option<Value>,
+
+    /// Stroke offset relative to the line's direction. Supports expressions.
+    #[serde(rename = "line-offset", skip_serializing_if = "Option::is_none")]
+    pub line_offset: Option<Value>,
+}
+
+/// Layout properties for a `line` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct LineLayout {
+    /// Whether this layer is displayed.
+    #[serde(default, deserialize_with = "deserialize_visibility_or_default")]
+    pub visibility: Visibility,
+
+    /// The display of line endings. Supports expressions.
+    #[serde(rename = "line-cap", skip_serializing_if = "Option::is_none")]
+    pub line_cap: Option<Value>,
+
+    /// The display of lines when joining. Supports expressions.
+    #[serde(rename = "line-join", skip_serializing_if = "Option::is_none")]
+    pub line_join: Option<Value>,
+
+    /// Used to automatically convert Miter joins to Bevel joins for sharp angles.
+    #[serde(rename = "line-miter-limit", skip_serializing_if = "Option::is_none")]
+    pub line_miter_limit: Option<Value>,
+
+    /// Used to automatically convert Round joins to Miter joins for slight angles.
+    #[serde(rename = "line-round-limit", skip_serializing_if = "Option::is_none")]
+    pub line_round_limit: Option<Value>,
+
+    /// Sorts features in ascending order by value. Features with a higher sort
+    /// key will appear above features with a lower sort key.
+    #[serde(rename = "line-sort-key", skip_serializing_if = "Option::is_none")]
+    pub line_sort_key: Option<Value>,
+}
+
+/// A `line` layer draws stroked lines.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct LineLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Source to use for this layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+
+    /// Layer within the source to use.
+    #[serde(rename = "source-layer", skip_serializing_if = "Option::is_none")]
+    pub source_layer: Option<String>,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Minimum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+
+    /// Maximum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Filter expression to select features from the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<Value>,
+
+    /// Layout properties.
+    #[serde(default)]
+    pub layout: LineLayout,
+
+    /// Paint properties.
+    #[serde(default)]
+    pub paint: LinePaint,
+}

--- a/galileo-maplibre/src/style/layer/misc.rs
+++ b/galileo-maplibre/src/style/layer/misc.rs
@@ -1,0 +1,153 @@
+//! Sky, slot, and clip layer types.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::common::{
+    default_layer_maxzoom, default_layer_minzoom, deserialize_maxzoom, deserialize_minzoom,
+    CommonLayout,
+};
+
+/// Paint properties for a `sky` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct SkyPaint {
+    /// Type of the sky rendering method.
+    #[serde(rename = "sky-type", skip_serializing_if = "Option::is_none")]
+    pub sky_type: Option<Value>,
+
+    /// A colour used to seed the atmosphere simulation.
+    #[serde(
+        rename = "sky-atmosphere-color",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sky_atmosphere_color: Option<Value>,
+
+    /// A colour applied to the atmosphere at halo radius from the sun.
+    #[serde(
+        rename = "sky-atmosphere-halo-color",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sky_atmosphere_halo_color: Option<Value>,
+
+    /// Position of the sun relative to the map.
+    #[serde(rename = "sky-atmosphere-sun", skip_serializing_if = "Option::is_none")]
+    pub sky_atmosphere_sun: Option<Value>,
+
+    /// Intensity of the sun as a light source in the atmosphere.
+    #[serde(
+        rename = "sky-atmosphere-sun-intensity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sky_atmosphere_sun_intensity: Option<Value>,
+
+    /// Defines a radial colour gradient.
+    #[serde(rename = "sky-gradient", skip_serializing_if = "Option::is_none")]
+    pub sky_gradient: Option<Value>,
+
+    /// Centre of the sky gradient.
+    #[serde(
+        rename = "sky-gradient-center",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sky_gradient_center: Option<Value>,
+
+    /// The angular distance from the gradient centre to its outer limits.
+    #[serde(
+        rename = "sky-gradient-radius",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sky_gradient_radius: Option<Value>,
+
+    /// The opacity of the entire sky layer.
+    #[serde(rename = "sky-opacity", skip_serializing_if = "Option::is_none")]
+    pub sky_opacity: Option<Value>,
+}
+
+/// Layout properties for a `sky` layer (visibility only).
+pub type SkyLayout = CommonLayout;
+
+/// A `sky` layer renders a stylized spherical dome.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SkyLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Minimum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+
+    /// Maximum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Layout properties.
+    #[serde(default)]
+    pub layout: SkyLayout,
+
+    /// Paint properties.
+    #[serde(default)]
+    pub paint: SkyPaint,
+}
+
+/// A `slot` layer acts as an insertion point for layers coming from imported styles.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SlotLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+/// A `clip` layer removes 3D content (models, extrusions) and/or symbols
+/// within the layer's geometry so that custom 3D content can be composited.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct ClipLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Source to use for this layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+
+    /// Layer within the source to use.
+    #[serde(rename = "source-layer", skip_serializing_if = "Option::is_none")]
+    pub source_layer: Option<String>,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Minimum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+
+    /// Maximum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Filter expression to select features from the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<Value>,
+
+    /// Types of content to clip: `"3d"` and/or `"symbols"`.
+    #[serde(rename = "clip-layer-types", skip_serializing_if = "Option::is_none")]
+    pub clip_layer_types: Option<Vec<String>>,
+}

--- a/galileo-maplibre/src/style/layer/mod.rs
+++ b/galileo-maplibre/src/style/layer/mod.rs
@@ -1,0 +1,349 @@
+//! Style layer definitions.
+//!
+//! Each MapLibre layer type has its own submodule. This module re-exports all
+//! public types and provides the [`Layer`] enum used in [`crate::style::MaplibreStyle`].
+
+pub mod background;
+pub mod common;
+pub mod fill;
+pub mod line;
+pub mod misc;
+pub mod point;
+pub mod raster;
+pub mod symbol;
+
+pub use background::{BackgroundLayer, BackgroundLayout, BackgroundPaint};
+pub use common::{CommonLayout, Visibility};
+pub use fill::{
+    FillExtrusionLayer, FillExtrusionLayout, FillExtrusionPaint, FillLayer, FillLayout, FillPaint,
+};
+pub use line::{LineLayer, LineLayout, LinePaint};
+pub use misc::{ClipLayer, SkyLayer, SkyLayout, SkyPaint, SlotLayer};
+pub use point::{
+    CircleLayer, CircleLayout, CirclePaint, HeatmapLayer, HeatmapLayout, HeatmapPaint,
+};
+pub use raster::{
+    HillshadeLayer, HillshadeLayout, HillshadePaint, RasterLayer, RasterLayout, RasterPaint,
+};
+use serde::Deserialize;
+pub use symbol::{SymbolLayer, SymbolLayout, SymbolPaint};
+
+/// A map layer — one of the supported rendering layer types.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(tag = "type")]
+pub enum Layer {
+    /// A background fill layer.
+    #[serde(rename = "background")]
+    Background(BackgroundLayer),
+    /// A filled polygon layer.
+    #[serde(rename = "fill")]
+    Fill(FillLayer),
+    /// A stroked line layer.
+    #[serde(rename = "line")]
+    Line(Box<LineLayer>),
+    /// An icon / text label layer.
+    #[serde(rename = "symbol")]
+    Symbol(Box<SymbolLayer>),
+    /// A raster tile layer.
+    #[serde(rename = "raster")]
+    Raster(RasterLayer),
+    /// A circle layer.
+    #[serde(rename = "circle")]
+    Circle(CircleLayer),
+    /// An extruded polygon (3D) layer.
+    #[serde(rename = "fill-extrusion")]
+    FillExtrusion(FillExtrusionLayer),
+    /// A heatmap layer.
+    #[serde(rename = "heatmap")]
+    Heatmap(HeatmapLayer),
+    /// A client-side hillshade layer.
+    #[serde(rename = "hillshade")]
+    Hillshade(HillshadeLayer),
+    /// A sky / atmosphere dome layer.
+    #[serde(rename = "sky")]
+    Sky(SkyLayer),
+    /// An insertion-point layer for imported styles.
+    #[serde(rename = "slot")]
+    Slot(SlotLayer),
+    /// A clipping mask layer.
+    #[serde(rename = "clip")]
+    Clip(ClipLayer),
+}
+
+#[cfg(test)]
+mod tests {
+    use common::{DEFAULT_MAXZOOM, DEFAULT_MINZOOM};
+
+    use super::*;
+
+    #[test]
+    fn parse_background_layer() {
+        let json = r#"{
+            "id": "Background",
+            "type": "background",
+            "layout": {"visibility": "visible"},
+            "paint": {"background-color": "hsl(47,79%,94%)"}
+        }"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Background(bg) = layer else {
+            panic!("expected Background")
+        };
+        assert_eq!(bg.id, "Background");
+        assert_eq!(bg.layout.visibility, Visibility::Visible);
+        assert_eq!(bg.minzoom, DEFAULT_MINZOOM);
+        assert_eq!(bg.maxzoom, DEFAULT_MAXZOOM);
+    }
+
+    #[test]
+    fn parse_fill_layer() {
+        let json = r#"{
+            "id": "Meadow",
+            "type": "fill",
+            "source": "maptiler_planet",
+            "source-layer": "globallandcover",
+            "maxzoom": 8,
+            "layout": {"visibility": "visible"},
+            "paint": {"fill-color": "hsl(75,51%,85%)", "fill-opacity": 0.5},
+            "filter": ["==", "class", "grass"]
+        }"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Fill(f) = layer else {
+            panic!("expected Fill")
+        };
+        assert_eq!(f.id, "Meadow");
+        assert_eq!(f.source.as_deref(), Some("maptiler_planet"));
+        assert_eq!(f.source_layer.as_deref(), Some("globallandcover"));
+        assert_eq!(f.maxzoom, 8.0);
+        assert!(f.filter.is_some());
+    }
+
+    #[test]
+    fn parse_line_layer() {
+        let json = r##"{
+            "id": "Road",
+            "type": "line",
+            "source": "maptiler_planet",
+            "source-layer": "transportation",
+            "layout": {"line-cap": "round", "line-join": "round", "visibility": "visible"},
+            "paint": {"line-color": "#fff", "line-width": 2}
+        }"##;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Line(l) = layer else {
+            panic!("expected Line")
+        };
+        assert_eq!(l.id, "Road");
+        assert!(l.layout.line_cap.is_some());
+        assert!(l.layout.line_join.is_some());
+    }
+
+    #[test]
+    fn parse_symbol_layer() {
+        let json = r##"{
+            "id": "Labels",
+            "type": "symbol",
+            "source": "maptiler_planet",
+            "source-layer": "place",
+            "layout": {
+                "text-field": "{name}",
+                "text-font": ["Open Sans Regular"],
+                "text-size": 12,
+                "visibility": "visible"
+            },
+            "paint": {
+                "text-color": "#333",
+                "text-halo-color": "#fff",
+                "text-halo-width": 1
+            }
+        }"##;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Symbol(s) = layer else {
+            panic!("expected Symbol")
+        };
+        assert_eq!(s.id, "Labels");
+        assert!(s.layout.text_field.is_some());
+        assert!(s.layout.text_font.is_some());
+    }
+
+    #[test]
+    fn parse_raster_layer() {
+        let json = r#"{
+            "id": "Satellite",
+            "type": "raster",
+            "source": "satellite",
+            "paint": {"raster-opacity": 1}
+        }"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Raster(r) = layer else {
+            panic!("expected Raster")
+        };
+        assert_eq!(r.id, "Satellite");
+        assert!(r.paint.raster_opacity.is_some());
+    }
+
+    #[test]
+    fn parse_circle_layer() {
+        let json = r##"{
+            "id": "Points",
+            "type": "circle",
+            "source": "my-source",
+            "paint": {"circle-color": "#f00", "circle-radius": 5}
+        }"##;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Circle(c) = layer else {
+            panic!("expected Circle")
+        };
+        assert_eq!(c.id, "Points");
+        assert!(c.paint.circle_color.is_some());
+    }
+
+    #[test]
+    fn parse_fill_extrusion_layer() {
+        let json = r##"{
+            "id": "Buildings",
+            "type": "fill-extrusion",
+            "source": "maptiler_planet",
+            "source-layer": "building",
+            "paint": {
+                "fill-extrusion-color": "#aaa",
+                "fill-extrusion-height": 10,
+                "fill-extrusion-base": 0,
+                "fill-extrusion-opacity": 0.6
+            }
+        }"##;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::FillExtrusion(fe) = layer else {
+            panic!("expected FillExtrusion")
+        };
+        assert_eq!(fe.id, "Buildings");
+        assert!(fe.paint.fill_extrusion_height.is_some());
+    }
+
+    #[test]
+    fn parse_heatmap_layer() {
+        let json = r#"{
+            "id": "Density",
+            "type": "heatmap",
+            "source": "earthquakes",
+            "paint": {"heatmap-radius": 30, "heatmap-opacity": 0.8}
+        }"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Heatmap(h) = layer else {
+            panic!("expected Heatmap")
+        };
+        assert_eq!(h.id, "Density");
+        assert!(h.paint.heatmap_opacity.is_some());
+    }
+
+    #[test]
+    fn parse_hillshade_layer() {
+        let json = r#"{
+            "id": "Terrain",
+            "type": "hillshade",
+            "source": "dem",
+            "paint": {"hillshade-exaggeration": 0.5}
+        }"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Hillshade(h) = layer else {
+            panic!("expected Hillshade")
+        };
+        assert_eq!(h.id, "Terrain");
+        assert!(h.paint.hillshade_exaggeration.is_some());
+    }
+
+    #[test]
+    fn parse_sky_layer() {
+        let json = r#"{
+            "id": "Sky",
+            "type": "sky",
+            "paint": {"sky-type": "atmosphere", "sky-opacity": 1}
+        }"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Sky(s) = layer else {
+            panic!("expected Sky")
+        };
+        assert_eq!(s.id, "Sky");
+        assert!(s.paint.sky_opacity.is_some());
+    }
+
+    #[test]
+    fn parse_slot_layer() {
+        let json = r#"{"id": "bottom", "type": "slot"}"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Slot(s) = layer else {
+            panic!("expected Slot")
+        };
+        assert_eq!(s.id, "bottom");
+    }
+
+    #[test]
+    fn parse_clip_layer() {
+        let json = r#"{
+            "id": "Clip",
+            "type": "clip",
+            "source": "composite",
+            "source-layer": "building",
+            "clip-layer-types": ["3d", "symbols"]
+        }"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Clip(c) = layer else {
+            panic!("expected Clip")
+        };
+        assert_eq!(c.id, "Clip");
+        assert_eq!(
+            c.clip_layer_types.as_deref(),
+            Some(["3d".to_string(), "symbols".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn unknown_layer_type_returns_error() {
+        let json = r#"{"id": "x", "type": "unknown"}"#;
+        assert!(serde_json::from_str::<Layer>(json).is_err());
+    }
+
+    #[test]
+    fn invalid_minzoom_falls_back_to_default() {
+        let json = r#"{"id": "x", "type": "fill", "source": "s", "minzoom": "bad"}"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Fill(f) = layer else {
+            panic!("expected Fill")
+        };
+        assert_eq!(f.minzoom, DEFAULT_MINZOOM);
+    }
+
+    #[test]
+    fn invalid_maxzoom_falls_back_to_default() {
+        let json = r#"{"id": "x", "type": "line", "source": "s", "maxzoom": "bad"}"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Line(l) = layer else {
+            panic!("expected Line")
+        };
+        assert_eq!(l.maxzoom, DEFAULT_MAXZOOM);
+    }
+
+    #[test]
+    fn invalid_visibility_falls_back_to_default() {
+        let json = r#"{
+            "id": "x",
+            "type": "fill",
+            "source": "s",
+            "layout": {"visibility": "bad-value"}
+        }"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Fill(f) = layer else {
+            panic!("expected Fill")
+        };
+        assert_eq!(f.layout.visibility, Visibility::Visible);
+    }
+
+    #[test]
+    fn missing_layout_uses_defaults() {
+        let json = r#"{"id": "x", "type": "background"}"#;
+        let layer: Layer = serde_json::from_str(json).unwrap();
+        let Layer::Background(bg) = layer else {
+            panic!("expected Background")
+        };
+        assert_eq!(bg.layout.visibility, Visibility::Visible);
+        assert!(bg.paint.background_color.is_none());
+    }
+}

--- a/galileo-maplibre/src/style/layer/point.rs
+++ b/galileo-maplibre/src/style/layer/point.rs
@@ -1,0 +1,215 @@
+//! Circle and heatmap layer types.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::common::{
+    default_layer_maxzoom, default_layer_minzoom, deserialize_maxzoom, deserialize_minzoom,
+    deserialize_visibility_or_default, CommonLayout, Visibility,
+};
+
+/// Paint properties for a `circle` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct CirclePaint {
+    /// Circle fill colour. Supports expressions.
+    #[serde(rename = "circle-color", skip_serializing_if = "Option::is_none")]
+    pub circle_color: Option<Value>,
+
+    /// Circle radius in pixels. Supports expressions.
+    #[serde(rename = "circle-radius", skip_serializing_if = "Option::is_none")]
+    pub circle_radius: Option<Value>,
+
+    /// Circle opacity. Supports expressions.
+    #[serde(rename = "circle-opacity", skip_serializing_if = "Option::is_none")]
+    pub circle_opacity: Option<Value>,
+
+    /// Width of the circle's stroke. Supports expressions.
+    #[serde(
+        rename = "circle-stroke-width",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub circle_stroke_width: Option<Value>,
+
+    /// Stroke colour of the circle. Supports expressions.
+    #[serde(
+        rename = "circle-stroke-color",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub circle_stroke_color: Option<Value>,
+
+    /// Stroke opacity. Supports expressions.
+    #[serde(
+        rename = "circle-stroke-opacity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub circle_stroke_opacity: Option<Value>,
+
+    /// Circle blur. Supports expressions.
+    #[serde(rename = "circle-blur", skip_serializing_if = "Option::is_none")]
+    pub circle_blur: Option<Value>,
+
+    /// Translation offset in pixels. Supports expressions.
+    #[serde(rename = "circle-translate", skip_serializing_if = "Option::is_none")]
+    pub circle_translate: Option<Value>,
+
+    /// Control whether the translation is relative to map or viewport.
+    #[serde(
+        rename = "circle-translate-anchor",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub circle_translate_anchor: Option<Value>,
+
+    /// Controls the scaling of the circle (map vs. viewport).
+    #[serde(rename = "circle-pitch-scale", skip_serializing_if = "Option::is_none")]
+    pub circle_pitch_scale: Option<Value>,
+
+    /// Orientation of circle when map is pitched.
+    #[serde(
+        rename = "circle-pitch-alignment",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub circle_pitch_alignment: Option<Value>,
+
+    /// Emission strength of the circle colour.
+    #[serde(
+        rename = "circle-emissive-strength",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub circle_emissive_strength: Option<Value>,
+}
+
+/// Layout properties for a `circle` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct CircleLayout {
+    /// Whether this layer is displayed.
+    #[serde(default, deserialize_with = "deserialize_visibility_or_default")]
+    pub visibility: Visibility,
+
+    /// Sorts features in ascending order by this value.
+    #[serde(rename = "circle-sort-key", skip_serializing_if = "Option::is_none")]
+    pub circle_sort_key: Option<Value>,
+}
+
+/// A `circle` layer draws circle symbols at points.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct CircleLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Source to use for this layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+
+    /// Layer within the source to use.
+    #[serde(rename = "source-layer", skip_serializing_if = "Option::is_none")]
+    pub source_layer: Option<String>,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Minimum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+
+    /// Maximum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Filter expression to select features from the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<Value>,
+
+    /// Layout properties.
+    #[serde(default)]
+    pub layout: CircleLayout,
+
+    /// Paint properties.
+    #[serde(default)]
+    pub paint: CirclePaint,
+}
+
+/// Paint properties for a `heatmap` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct HeatmapPaint {
+    /// Radius of influence of one heatmap point. Supports expressions.
+    #[serde(rename = "heatmap-radius", skip_serializing_if = "Option::is_none")]
+    pub heatmap_radius: Option<Value>,
+
+    /// Weight of each individual data point. Supports expressions.
+    #[serde(rename = "heatmap-weight", skip_serializing_if = "Option::is_none")]
+    pub heatmap_weight: Option<Value>,
+
+    /// Controls the intensity of the heatmap. Supports expressions.
+    #[serde(rename = "heatmap-intensity", skip_serializing_if = "Option::is_none")]
+    pub heatmap_intensity: Option<Value>,
+
+    /// Defines the colour of each pixel based on its density value.
+    #[serde(rename = "heatmap-color", skip_serializing_if = "Option::is_none")]
+    pub heatmap_color: Option<Value>,
+
+    /// Opacity of the entire heatmap layer. Supports expressions.
+    #[serde(rename = "heatmap-opacity", skip_serializing_if = "Option::is_none")]
+    pub heatmap_opacity: Option<Value>,
+
+    /// Emission strength of the heatmap colour.
+    #[serde(
+        rename = "heatmap-emissive-strength",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub heatmap_emissive_strength: Option<Value>,
+}
+
+/// Layout properties for a `heatmap` layer (visibility only).
+pub type HeatmapLayout = CommonLayout;
+
+/// A `heatmap` layer renders a heatmap.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct HeatmapLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Source to use for this layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+
+    /// Layer within the source to use.
+    #[serde(rename = "source-layer", skip_serializing_if = "Option::is_none")]
+    pub source_layer: Option<String>,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Minimum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+
+    /// Maximum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Filter expression to select features from the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<Value>,
+
+    /// Layout properties.
+    #[serde(default)]
+    pub layout: HeatmapLayout,
+
+    /// Paint properties.
+    #[serde(default)]
+    pub paint: HeatmapPaint,
+}

--- a/galileo-maplibre/src/style/layer/raster.rs
+++ b/galileo-maplibre/src/style/layer/raster.rs
@@ -1,0 +1,206 @@
+//! Raster and hillshade layer types.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::common::{
+    default_layer_maxzoom, default_layer_minzoom, deserialize_maxzoom, deserialize_minzoom,
+    CommonLayout,
+};
+
+/// Paint properties for a `raster` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct RasterPaint {
+    /// Opacity of the raster layer. Supports expressions.
+    #[serde(rename = "raster-opacity", skip_serializing_if = "Option::is_none")]
+    pub raster_opacity: Option<Value>,
+
+    /// Rotates hues around the colour wheel. Supports expressions.
+    #[serde(rename = "raster-hue-rotate", skip_serializing_if = "Option::is_none")]
+    pub raster_hue_rotate: Option<Value>,
+
+    /// Increase or reduce the brightness of the image (minimum). Supports expressions.
+    #[serde(
+        rename = "raster-brightness-min",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub raster_brightness_min: Option<Value>,
+
+    /// Increase or reduce the brightness of the image (maximum). Supports expressions.
+    #[serde(
+        rename = "raster-brightness-max",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub raster_brightness_max: Option<Value>,
+
+    /// Increase or reduce the saturation of the image. Supports expressions.
+    #[serde(rename = "raster-saturation", skip_serializing_if = "Option::is_none")]
+    pub raster_saturation: Option<Value>,
+
+    /// Increase or reduce the contrast of the image. Supports expressions.
+    #[serde(rename = "raster-contrast", skip_serializing_if = "Option::is_none")]
+    pub raster_contrast: Option<Value>,
+
+    /// The resampling/interpolation method to use for overscaling.
+    #[serde(rename = "raster-resampling", skip_serializing_if = "Option::is_none")]
+    pub raster_resampling: Option<Value>,
+
+    /// Fade duration when a new tile is added. Supports expressions.
+    #[serde(
+        rename = "raster-fade-duration",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub raster_fade_duration: Option<Value>,
+
+    /// Emission strength of the raster colour.
+    #[serde(
+        rename = "raster-emissive-strength",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub raster_emissive_strength: Option<Value>,
+}
+
+/// Layout properties for a `raster` layer (visibility only).
+pub type RasterLayout = CommonLayout;
+
+/// A `raster` layer renders raster tiles.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct RasterLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Source to use for this layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+
+    /// Layer within the source to use.
+    #[serde(rename = "source-layer", skip_serializing_if = "Option::is_none")]
+    pub source_layer: Option<String>,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Minimum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+
+    /// Maximum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Filter expression to select features from the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<Value>,
+
+    /// Layout properties.
+    #[serde(default)]
+    pub layout: RasterLayout,
+
+    /// Paint properties.
+    #[serde(default)]
+    pub paint: RasterPaint,
+}
+
+/// Paint properties for a `hillshade` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct HillshadePaint {
+    /// The direction of the light source. Supports expressions.
+    #[serde(
+        rename = "hillshade-illumination-direction",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub hillshade_illumination_direction: Option<Value>,
+
+    /// Whether the illumination is relative to map north or viewport north.
+    #[serde(
+        rename = "hillshade-illumination-anchor",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub hillshade_illumination_anchor: Option<Value>,
+
+    /// Intensity of the hillshade. Supports expressions.
+    #[serde(
+        rename = "hillshade-exaggeration",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub hillshade_exaggeration: Option<Value>,
+
+    /// The shading colour of areas that face away from the light source.
+    #[serde(
+        rename = "hillshade-shadow-color",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub hillshade_shadow_color: Option<Value>,
+
+    /// The shading colour of areas that faces towards the light source.
+    #[serde(
+        rename = "hillshade-highlight-color",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub hillshade_highlight_color: Option<Value>,
+
+    /// The shading colour used to accentuate rugged terrain.
+    #[serde(
+        rename = "hillshade-accent-color",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub hillshade_accent_color: Option<Value>,
+
+    /// Emission strength of the hillshade colour.
+    #[serde(
+        rename = "hillshade-emissive-strength",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub hillshade_emissive_strength: Option<Value>,
+}
+
+/// Layout properties for a `hillshade` layer (visibility only).
+pub type HillshadeLayout = CommonLayout;
+
+/// A `hillshade` layer renders a client-side hillshade from a raster DEM source.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct HillshadeLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Source to use for this layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+
+    /// Layer within the source to use.
+    #[serde(rename = "source-layer", skip_serializing_if = "Option::is_none")]
+    pub source_layer: Option<String>,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Minimum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+
+    /// Maximum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Layout properties.
+    #[serde(default)]
+    pub layout: HillshadeLayout,
+
+    /// Paint properties.
+    #[serde(default)]
+    pub paint: HillshadePaint,
+}

--- a/galileo-maplibre/src/style/layer/symbol.rs
+++ b/galileo-maplibre/src/style/layer/symbol.rs
@@ -1,0 +1,315 @@
+//! Symbol layer types.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::common::{
+    default_layer_maxzoom, default_layer_minzoom, deserialize_maxzoom, deserialize_minzoom,
+    deserialize_visibility_or_default, Visibility,
+};
+
+/// Paint properties for a `symbol` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct SymbolPaint {
+    /// Icon colour. Supports expressions.
+    #[serde(rename = "icon-color", skip_serializing_if = "Option::is_none")]
+    pub icon_color: Option<Value>,
+
+    /// Icon halo colour. Supports expressions.
+    #[serde(rename = "icon-halo-color", skip_serializing_if = "Option::is_none")]
+    pub icon_halo_color: Option<Value>,
+
+    /// Width of the halo around the icon. Supports expressions.
+    #[serde(rename = "icon-halo-width", skip_serializing_if = "Option::is_none")]
+    pub icon_halo_width: Option<Value>,
+
+    /// Fade out the halo towards the outside. Supports expressions.
+    #[serde(rename = "icon-halo-blur", skip_serializing_if = "Option::is_none")]
+    pub icon_halo_blur: Option<Value>,
+
+    /// Icon opacity. Supports expressions.
+    #[serde(rename = "icon-opacity", skip_serializing_if = "Option::is_none")]
+    pub icon_opacity: Option<Value>,
+
+    /// Icon translation offset. Supports expressions.
+    #[serde(rename = "icon-translate", skip_serializing_if = "Option::is_none")]
+    pub icon_translate: Option<Value>,
+
+    /// Control whether the icon translation is relative to map or viewport.
+    #[serde(
+        rename = "icon-translate-anchor",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub icon_translate_anchor: Option<Value>,
+
+    /// Emission strength of the icon colour.
+    #[serde(
+        rename = "icon-emissive-strength",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub icon_emissive_strength: Option<Value>,
+
+    /// Text colour. Supports expressions.
+    #[serde(rename = "text-color", skip_serializing_if = "Option::is_none")]
+    pub text_color: Option<Value>,
+
+    /// Text halo colour. Supports expressions.
+    #[serde(rename = "text-halo-color", skip_serializing_if = "Option::is_none")]
+    pub text_halo_color: Option<Value>,
+
+    /// Width of the halo around text. Supports expressions.
+    #[serde(rename = "text-halo-width", skip_serializing_if = "Option::is_none")]
+    pub text_halo_width: Option<Value>,
+
+    /// Fade out the halo towards the outside. Supports expressions.
+    #[serde(rename = "text-halo-blur", skip_serializing_if = "Option::is_none")]
+    pub text_halo_blur: Option<Value>,
+
+    /// Text opacity. Supports expressions.
+    #[serde(rename = "text-opacity", skip_serializing_if = "Option::is_none")]
+    pub text_opacity: Option<Value>,
+
+    /// Text translation offset. Supports expressions.
+    #[serde(rename = "text-translate", skip_serializing_if = "Option::is_none")]
+    pub text_translate: Option<Value>,
+
+    /// Control whether the text translation is relative to map or viewport.
+    #[serde(
+        rename = "text-translate-anchor",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub text_translate_anchor: Option<Value>,
+
+    /// Emission strength of the text colour.
+    #[serde(
+        rename = "text-emissive-strength",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub text_emissive_strength: Option<Value>,
+}
+
+/// Layout properties for a `symbol` layer.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct SymbolLayout {
+    /// Whether this layer is displayed.
+    #[serde(default, deserialize_with = "deserialize_visibility_or_default")]
+    pub visibility: Visibility,
+
+    /// Label placement relative to its geometry. Supports expressions.
+    #[serde(rename = "symbol-placement", skip_serializing_if = "Option::is_none")]
+    pub symbol_placement: Option<Value>,
+
+    /// Distance between two symbol anchors. Supports expressions.
+    #[serde(rename = "symbol-spacing", skip_serializing_if = "Option::is_none")]
+    pub symbol_spacing: Option<Value>,
+
+    /// Whether symbols can be placed at map edges.
+    #[serde(rename = "symbol-avoid-edges", skip_serializing_if = "Option::is_none")]
+    pub symbol_avoid_edges: Option<Value>,
+
+    /// Determines whether overlapping symbols in the same layer are hidden.
+    #[serde(rename = "symbol-sort-key", skip_serializing_if = "Option::is_none")]
+    pub symbol_sort_key: Option<Value>,
+
+    /// Controls the order in which overlapping symbols are rendered.
+    #[serde(rename = "symbol-z-order", skip_serializing_if = "Option::is_none")]
+    pub symbol_z_order: Option<Value>,
+
+    /// If true, the icon will be visible even if it collides with other icons.
+    #[serde(rename = "icon-allow-overlap", skip_serializing_if = "Option::is_none")]
+    pub icon_allow_overlap: Option<Value>,
+
+    /// Part of the icon placed nearest to the anchor.
+    #[serde(rename = "icon-anchor", skip_serializing_if = "Option::is_none")]
+    pub icon_anchor: Option<Value>,
+
+    /// If true, other symbols can be visible even if they collide with the icon.
+    #[serde(
+        rename = "icon-ignore-placement",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub icon_ignore_placement: Option<Value>,
+
+    /// Name of an image in the sprite to use for drawing an icon.
+    #[serde(rename = "icon-image", skip_serializing_if = "Option::is_none")]
+    pub icon_image: Option<Value>,
+
+    /// If true, the icon may be flipped to prevent text label being upside-down.
+    #[serde(rename = "icon-keep-upright", skip_serializing_if = "Option::is_none")]
+    pub icon_keep_upright: Option<Value>,
+
+    /// Offset distance of icon from its anchor. Supports expressions.
+    #[serde(rename = "icon-offset", skip_serializing_if = "Option::is_none")]
+    pub icon_offset: Option<Value>,
+
+    /// If true, text is optional when icon is blocked.
+    #[serde(rename = "icon-optional", skip_serializing_if = "Option::is_none")]
+    pub icon_optional: Option<Value>,
+
+    /// Size of the additional area around the icon used to detect collisions.
+    #[serde(rename = "icon-padding", skip_serializing_if = "Option::is_none")]
+    pub icon_padding: Option<Value>,
+
+    /// Rotates the icon clockwise. Supports expressions.
+    #[serde(rename = "icon-rotate", skip_serializing_if = "Option::is_none")]
+    pub icon_rotate: Option<Value>,
+
+    /// In combination with `symbol-placement`, determines the rotation of the icon.
+    #[serde(
+        rename = "icon-rotation-alignment",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub icon_rotation_alignment: Option<Value>,
+
+    /// Scales the icon. Supports expressions.
+    #[serde(rename = "icon-size", skip_serializing_if = "Option::is_none")]
+    pub icon_size: Option<Value>,
+
+    /// Positions icon relative to other icons.
+    #[serde(rename = "icon-text-fit", skip_serializing_if = "Option::is_none")]
+    pub icon_text_fit: Option<Value>,
+
+    /// Padding around the text when `icon-text-fit` is used.
+    #[serde(
+        rename = "icon-text-fit-padding",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub icon_text_fit_padding: Option<Value>,
+
+    /// If true, the text is visible even if it collides.
+    #[serde(rename = "text-allow-overlap", skip_serializing_if = "Option::is_none")]
+    pub text_allow_overlap: Option<Value>,
+
+    /// Part of the text placed nearest to the anchor. Supports expressions.
+    #[serde(rename = "text-anchor", skip_serializing_if = "Option::is_none")]
+    pub text_anchor: Option<Value>,
+
+    /// Value to use for a text label. Supports expressions.
+    #[serde(rename = "text-field", skip_serializing_if = "Option::is_none")]
+    pub text_field: Option<Value>,
+
+    /// Font stack for the glyphs. Supports expressions.
+    #[serde(rename = "text-font", skip_serializing_if = "Option::is_none")]
+    pub text_font: Option<Value>,
+
+    /// If true, other symbols can be visible even if they collide with the text.
+    #[serde(
+        rename = "text-ignore-placement",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub text_ignore_placement: Option<Value>,
+
+    /// Text justification. Supports expressions.
+    #[serde(rename = "text-justify", skip_serializing_if = "Option::is_none")]
+    pub text_justify: Option<Value>,
+
+    /// If true, the text may be flipped vertically when rotated.
+    #[serde(rename = "text-keep-upright", skip_serializing_if = "Option::is_none")]
+    pub text_keep_upright: Option<Value>,
+
+    /// Text tracking. Supports expressions.
+    #[serde(
+        rename = "text-letter-spacing",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub text_letter_spacing: Option<Value>,
+
+    /// Text leading value. Supports expressions.
+    #[serde(rename = "text-line-height", skip_serializing_if = "Option::is_none")]
+    pub text_line_height: Option<Value>,
+
+    /// Maximum angle change between adjacent characters. Supports expressions.
+    #[serde(rename = "text-max-angle", skip_serializing_if = "Option::is_none")]
+    pub text_max_angle: Option<Value>,
+
+    /// The maximum line width for text wrapping. Supports expressions.
+    #[serde(rename = "text-max-width", skip_serializing_if = "Option::is_none")]
+    pub text_max_width: Option<Value>,
+
+    /// Offset distance of text from its anchor. Supports expressions.
+    #[serde(rename = "text-offset", skip_serializing_if = "Option::is_none")]
+    pub text_offset: Option<Value>,
+
+    /// If true, icons are optional when text is blocked.
+    #[serde(rename = "text-optional", skip_serializing_if = "Option::is_none")]
+    pub text_optional: Option<Value>,
+
+    /// Size of the additional area around the text used to detect collisions.
+    #[serde(rename = "text-padding", skip_serializing_if = "Option::is_none")]
+    pub text_padding: Option<Value>,
+
+    /// Radial offset of text. Supports expressions.
+    #[serde(rename = "text-radial-offset", skip_serializing_if = "Option::is_none")]
+    pub text_radial_offset: Option<Value>,
+
+    /// In combination with `symbol-placement`, determines the rotation of the text.
+    #[serde(
+        rename = "text-rotation-alignment",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub text_rotation_alignment: Option<Value>,
+
+    /// Font size. Supports expressions.
+    #[serde(rename = "text-size", skip_serializing_if = "Option::is_none")]
+    pub text_size: Option<Value>,
+
+    /// Specifies how to capitalize text. Supports expressions.
+    #[serde(rename = "text-transform", skip_serializing_if = "Option::is_none")]
+    pub text_transform: Option<Value>,
+
+    /// To increase the chance of placing high-priority labels on the map.
+    #[serde(
+        rename = "text-variable-anchor",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub text_variable_anchor: Option<Value>,
+
+    /// The property to use as a feature's writing direction.
+    #[serde(rename = "text-writing-mode", skip_serializing_if = "Option::is_none")]
+    pub text_writing_mode: Option<Value>,
+}
+
+/// A `symbol` layer draws icons or text labels at points or along lines.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SymbolLayer {
+    /// Unique layer identifier.
+    pub id: String,
+
+    /// Source to use for this layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+
+    /// Layer within the source to use.
+    #[serde(rename = "source-layer", skip_serializing_if = "Option::is_none")]
+    pub source_layer: Option<String>,
+
+    /// Arbitrary properties for tracking the layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Minimum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_minzoom",
+        deserialize_with = "deserialize_minzoom"
+    )]
+    pub minzoom: f64,
+
+    /// Maximum zoom level at which to show this layer.
+    #[serde(
+        default = "default_layer_maxzoom",
+        deserialize_with = "deserialize_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Filter expression to select features from the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<Value>,
+
+    /// Layout properties.
+    #[serde(default)]
+    pub layout: SymbolLayout,
+
+    /// Paint properties.
+    #[serde(default)]
+    pub paint: SymbolPaint,
+}

--- a/galileo-maplibre/src/style/mod.rs
+++ b/galileo-maplibre/src/style/mod.rs
@@ -1,0 +1,582 @@
+//! Maplibre / Mapbox GL style specification — Rust representation.
+//!
+//! This module provides a type-safe, best-effort deserialisation of the
+//! [MapLibre Style Specification v8](https://maplibre.org/maplibre-style-spec/).
+//! Unknown or malformed values are logged at `warn` level via the `log` crate
+//! and then skipped, so a partially-recognised style is still usable.
+//!
+//! # Submodules
+//! - [`source`] — data source definitions (`vector`, `raster`, `geojson`, …)
+
+pub mod expression;
+pub(super) mod helpers;
+pub mod layer;
+pub mod source;
+pub mod value;
+
+use std::collections::HashMap;
+
+use layer::Layer;
+use serde::Deserialize;
+use serde_json::Value;
+use source::Source;
+
+/// A single sprite definition referencing an external sprite sheet.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct SpriteEntry {
+    /// Unique identifier for the sprite. When set to `"default"`, the prefix
+    /// is omitted when referencing images from this sprite.
+    pub id: String,
+    /// URL of the sprite sheet (without the `.json`/`.png` extension; both are
+    /// loaded automatically).
+    pub url: String,
+}
+
+/// The sprite value in a MapLibre style.
+///
+/// Can be either a single URL string (legacy / backwards-compatible form) or
+/// an array of [`SpriteEntry`] objects.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Sprite {
+    /// Legacy single-URL form.
+    Url(String),
+    /// Array of `{id, url}` objects.
+    Entries(Vec<SpriteEntry>),
+}
+
+impl<'de> Deserialize<'de> for Sprite {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        match &value {
+            Value::String(s) => Ok(Sprite::Url(s.clone())),
+            Value::Array(_) => serde_json::from_value::<Vec<SpriteEntry>>(value)
+                .map(Sprite::Entries)
+                .map_err(serde::de::Error::custom),
+            other => Err(serde::de::Error::custom(format!(
+                "sprite must be a string or array, got {other}"
+            ))),
+        }
+    }
+}
+
+/// Global transition timing defaults.
+///
+/// Used as the default transition for all paint properties that support
+/// transitions unless overridden by a property-specific transition.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+pub struct Transition {
+    /// Duration in milliseconds over which properties transition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<f64>,
+    /// Delay in milliseconds before the transition begins.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delay: Option<f64>,
+}
+
+/// Root-level MapLibre GL style document (specification version 8).
+///
+/// A style's top-level properties define the map's layers, tile sources and
+/// other rendering settings.  See the
+/// [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/)
+/// for the full reference.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct MaplibreStyle {
+    /// Must be `8`. Identifies the style specification version.
+    pub version: u32,
+
+    /// A human-readable name for the style.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Arbitrary properties useful to track with the stylesheet. These do not
+    /// influence rendering. Properties should be prefixed to avoid collisions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+
+    /// Default map center as `[longitude, latitude]`. Used only if the map has
+    /// not been positioned by other means.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_center"
+    )]
+    pub center: Option<[f64; 2]>,
+
+    /// Default map center altitude in metres above sea level.
+    #[serde(
+        rename = "centerAltitude",
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_f64"
+    )]
+    pub center_altitude: Option<f64>,
+
+    /// Default zoom level. Used only if the map has not been positioned by
+    /// other means.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_f64"
+    )]
+    pub zoom: Option<f64>,
+
+    /// Default bearing in degrees. Zero points north. Used only if the map has
+    /// not been positioned by other means.
+    #[serde(default, deserialize_with = "deserialize_f64_or_default")]
+    pub bearing: f64,
+
+    /// Default pitch in degrees. Zero is a straight-down view. Used only if
+    /// the map has not been positioned by other means.
+    #[serde(default, deserialize_with = "deserialize_f64_or_default")]
+    pub pitch: f64,
+
+    /// Default roll in degrees, measured counterclockwise about the camera
+    /// boresight. Used only if the map has not been positioned by other means.
+    #[serde(default, deserialize_with = "deserialize_f64_or_default")]
+    pub roll: f64,
+
+    /// Data sources referenced by the style's layers.
+    #[serde(deserialize_with = "deserialize_sources")]
+    pub sources: HashMap<String, Source>,
+
+    /// Sprite sheet URL or array of sprite entries.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_opt_sprite"
+    )]
+    pub sprite: Option<Sprite>,
+
+    /// URL template for loading SDF glyph sets in PBF format.
+    /// Must contain `{fontstack}` and `{range}` tokens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub glyphs: Option<String>,
+
+    /// Global transition timing defaults.
+    #[serde(default, deserialize_with = "deserialize_transition_or_default")]
+    pub transition: Transition,
+
+    /// Ordered list of layers to render.
+    #[serde(deserialize_with = "deserialize_layers")]
+    pub layers: Vec<Layer>,
+}
+
+impl MaplibreStyle {
+    /// Parse a MapLibre style from a JSON string.
+    ///
+    /// Unknown top-level fields are logged at `warn` level. A warning is also
+    /// emitted when `version` is not `8`. Individual sources or layers that
+    /// cannot be understood are logged and skipped rather than failing the
+    /// whole parse.
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        let de = &mut serde_json::Deserializer::from_str(json);
+        let style: Self = serde_ignored::deserialize(de, |path| {
+            log::warn!("Unrecognised style field: {path}");
+        })?;
+
+        if style.version != 8 {
+            log::warn!(
+                "Unsupported style version {} (expected 8); parsing will continue best-effort",
+                style.version
+            );
+        }
+
+        Ok(style)
+    }
+}
+
+/// Deserialises the `sources` map, logging and skipping any entry that fails
+/// to parse rather than hard-failing the whole document.
+fn deserialize_sources<'de, D>(deserializer: D) -> Result<HashMap<String, Source>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: HashMap<String, Value> = HashMap::deserialize(deserializer)?;
+    let mut out = HashMap::with_capacity(raw.len());
+    for (key, val) in raw {
+        let json_str = val.to_string();
+        let de = &mut serde_json::Deserializer::from_str(&json_str);
+        match serde_ignored::deserialize(de, |path| {
+            log::warn!("Unrecognised field in source {key:?}: {path}");
+        }) {
+            Ok(src) => {
+                out.insert(key, src);
+            }
+            Err(err) => {
+                log::warn!("Failed to parse source {key:?}: {err}");
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Deserialises the `layers` array, logging and skipping any entry that cannot
+/// be parsed (unknown type or malformed data) rather than failing the whole document.
+fn deserialize_layers<'de, D>(deserializer: D) -> Result<Vec<Layer>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: Vec<Value> = Vec::deserialize(deserializer)?;
+    let mut out = Vec::with_capacity(raw.len());
+    for val in raw {
+        let id = val
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("<unknown>");
+        let json_str = val.to_string();
+        let de = &mut serde_json::Deserializer::from_str(&json_str);
+        match serde_ignored::deserialize(de, |path| {
+            log::warn!("Unrecognised field in layer {id:?}: {path}");
+        }) {
+            Ok(layer) => out.push(layer),
+            Err(err) => log::warn!("Failed to parse layer {id:?}: {err}; skipping"),
+        }
+    }
+    Ok(out)
+}
+
+/// Deserialises a required `f64` field, falling back to `Default` and logging
+/// a warning when the value is present but not a valid number.
+fn deserialize_f64_or_default<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(f64::default()),
+        v => serde_json::from_value::<f64>(v.clone()).or_else(|err| {
+            log::warn!("Invalid f64 value {v}: {err}; using default");
+            Ok(f64::default())
+        }),
+    }
+}
+
+/// Deserialises an optional `f64` field, falling back to `None` and logging a
+/// warning when the value is present but cannot be parsed as a number.
+fn deserialize_opt_f64<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(None),
+        v => match serde_json::from_value::<f64>(v.clone()) {
+            Ok(n) => Ok(Some(n)),
+            Err(err) => {
+                log::warn!("Invalid f64 value {v}: {err}; ignoring field");
+                Ok(None)
+            }
+        },
+    }
+}
+
+/// Deserialises an optional `[f64; 2]` center field, falling back to `None`
+/// and logging a warning on parse failure.
+fn deserialize_opt_center<'de, D>(deserializer: D) -> Result<Option<[f64; 2]>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(None),
+        v => match serde_json::from_value::<[f64; 2]>(v.clone()) {
+            Ok(c) => Ok(Some(c)),
+            Err(err) => {
+                log::warn!("Invalid center value {v}: {err}; ignoring field");
+                Ok(None)
+            }
+        },
+    }
+}
+
+/// Deserialises an optional [`Sprite`] field, falling back to `None` and
+/// logging a warning when the value cannot be parsed.
+fn deserialize_opt_sprite<'de, D>(deserializer: D) -> Result<Option<Sprite>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(None),
+        v => match serde_json::from_value::<Sprite>(v.clone()) {
+            Ok(s) => Ok(Some(s)),
+            Err(err) => {
+                log::warn!("Invalid sprite value {v}: {err}; ignoring field");
+                Ok(None)
+            }
+        },
+    }
+}
+
+/// Deserialises a [`Transition`] field, falling back to `Default` and logging
+/// a warning when the value is present but malformed.
+fn deserialize_transition_or_default<'de, D>(deserializer: D) -> Result<Transition, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(Transition::default()),
+        v => match serde_json::from_value::<Transition>(v.clone()) {
+            Ok(t) => Ok(t),
+            Err(err) => {
+                log::warn!("Invalid transition value {v}: {err}; using default");
+                Ok(Transition::default())
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal valid style — only required fields.
+    const MINIMAL: &str = r#"{
+        "version": 8,
+        "sources": {},
+        "layers": []
+    }"#;
+
+    #[test]
+    fn parse_minimal_style() {
+        let style = MaplibreStyle::from_json(MINIMAL).unwrap();
+        assert_eq!(style.version, 8);
+        assert!(style.name.is_none());
+        assert!(style.sources.is_empty());
+        assert!(style.layers.is_empty());
+        assert_eq!(style.bearing, 0.0);
+        assert_eq!(style.pitch, 0.0);
+    }
+
+    #[test]
+    fn parse_optional_scalars() {
+        let json = r#"{
+            "version": 8,
+            "name": "Test Style",
+            "center": [-73.97, 40.77],
+            "zoom": 12.5,
+            "bearing": 29.0,
+            "pitch": 50.0,
+            "glyphs": "https://example.com/fonts/{fontstack}/{range}.pbf",
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert_eq!(style.name.as_deref(), Some("Test Style"));
+        assert_eq!(style.center, Some([-73.97, 40.77]));
+        assert_eq!(style.zoom, Some(12.5));
+        assert_eq!(style.bearing, 29.0);
+        assert_eq!(style.pitch, 50.0);
+        assert_eq!(
+            style.glyphs.as_deref(),
+            Some("https://example.com/fonts/{fontstack}/{range}.pbf")
+        );
+    }
+
+    #[test]
+    fn parse_sprite_url() {
+        let json = r#"{
+            "version": 8,
+            "sprite": "https://example.com/sprite",
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert_eq!(
+            style.sprite,
+            Some(Sprite::Url("https://example.com/sprite".into()))
+        );
+    }
+
+    #[test]
+    fn parse_sprite_entries() {
+        let json = r#"{
+            "version": 8,
+            "sprite": [
+                {"id": "default", "url": "https://example.com/sprite"},
+                {"id": "extra",   "url": "https://example.com/extra-sprite"}
+            ],
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        let Sprite::Entries(entries) = style.sprite.unwrap() else {
+            panic!("expected Entries");
+        };
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].id, "default");
+    }
+
+    #[test]
+    fn parse_transition() {
+        let json = r#"{
+            "version": 8,
+            "transition": {"duration": 300, "delay": 0},
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert_eq!(style.transition.duration, Some(300.0));
+        assert_eq!(style.transition.delay, Some(0.0));
+    }
+
+    #[test]
+    fn parse_sources_in_style() {
+        let json = r#"{
+            "version": 8,
+            "sources": {
+                "my_tiles": {"type": "vector", "url": "https://example.com/tiles.json"}
+            },
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert!(style.sources.contains_key("my_tiles"));
+    }
+
+    #[test]
+    fn bad_source_is_skipped() {
+        let json = r#"{
+            "version": 8,
+            "sources": {
+                "good": {"type": "vector", "url": "https://example.com/tiles.json"},
+                "bad":  {"type": "nonexistent"}
+            },
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        // The bad source is skipped; the good one is retained.
+        assert!(style.sources.contains_key("good"));
+        assert!(!style.sources.contains_key("bad"));
+    }
+
+    #[test]
+    fn parse_maptiler_style_root() {
+        // Root-level fields from the maptiler_fmt.json fixture.
+        let json = r#"{
+            "version": 8,
+            "id": "streets-v2",
+            "name": "Streets",
+            "sources": {
+                "maptiler_attribution": {
+                    "attribution": "© MapTiler",
+                    "type": "vector"
+                },
+                "maptiler_planet": {
+                    "url": "https://api.maptiler.com/tiles/v3/tiles.json?key=xxx",
+                    "type": "vector"
+                }
+            },
+            "layers": [],
+            "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=xxx",
+            "sprite": "https://api.maptiler.com/maps/streets-v2/sprite",
+            "bearing": 0,
+            "pitch": 0,
+            "center": [0, 0],
+            "zoom": 1
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert_eq!(style.version, 8);
+        assert_eq!(style.name.as_deref(), Some("Streets"));
+        assert_eq!(style.sources.len(), 2);
+        assert_eq!(style.zoom, Some(1.0));
+        assert_eq!(style.center, Some([0.0, 0.0]));
+        assert!(matches!(style.sprite, Some(Sprite::Url(_))));
+    }
+
+    #[test]
+    fn unknown_top_level_field_is_tolerated() {
+        // "id" and "foo" are not in the spec; they should be ignored (logged).
+        let json = r#"{
+            "version": 8,
+            "id": "my-style",
+            "foo": 42,
+            "sources": {},
+            "layers": []
+        }"#;
+        // Must not return an error.
+        MaplibreStyle::from_json(json).unwrap();
+    }
+
+    #[test]
+    fn invalid_version_is_tolerated() {
+        // Version 7 is unrecognised but we still parse best-effort.
+        let json = r#"{
+            "version": 7,
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert_eq!(style.version, 7);
+    }
+
+    #[test]
+    fn invalid_bearing_falls_back_to_default() {
+        let json = r#"{
+            "version": 8,
+            "bearing": "not-a-number",
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert_eq!(style.bearing, 0.0);
+    }
+
+    #[test]
+    fn invalid_pitch_falls_back_to_default() {
+        let json = r#"{
+            "version": 8,
+            "pitch": true,
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert_eq!(style.pitch, 0.0);
+    }
+
+    #[test]
+    fn invalid_zoom_falls_back_to_none() {
+        let json = r#"{
+            "version": 8,
+            "zoom": "far",
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert!(style.zoom.is_none());
+    }
+
+    #[test]
+    fn invalid_center_falls_back_to_none() {
+        let json = r#"{
+            "version": 8,
+            "center": "not-an-array",
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert!(style.center.is_none());
+    }
+
+    #[test]
+    fn invalid_sprite_falls_back_to_none() {
+        let json = r#"{
+            "version": 8,
+            "sprite": 42,
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert!(style.sprite.is_none());
+    }
+
+    #[test]
+    fn invalid_transition_falls_back_to_default() {
+        let json = r#"{
+            "version": 8,
+            "transition": "instant",
+            "sources": {},
+            "layers": []
+        }"#;
+        let style = MaplibreStyle::from_json(json).unwrap();
+        assert_eq!(style.transition, Transition::default());
+    }
+}

--- a/galileo-maplibre/src/style/source.rs
+++ b/galileo-maplibre/src/style/source.rs
@@ -1,0 +1,762 @@
+//! Style sources — specifications of data that map layers are drawn from.
+//!
+//! Sources state which data the map should displayfn default_minzoom() -> f64 {f source
+//! with the `type` property. Adding a source isn't enough to make data appear
+//! on the map because sources don't contain styling details like color or width.
+//! Layers refer to a source and give it a visual representation. This makes it
+//! possible to style the same source in different ways.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::helpers::deserialize_f64_with_fallback;
+
+const DEFAULT_MINZOOM: f64 = 0.0;
+const DEFAULT_MAXZOOM: f64 = 22.0;
+const DEFAULT_TILE_SIZE: f64 = 512.0;
+const DEFAULT_FACTOR: f64 = 1.0;
+const DEFAULT_GEOJSON_MAXZOOM: f64 = 18.0;
+const DEFAULT_BUFFER: f64 = 128.0;
+const DEFAULT_TOLERANCE: f64 = 0.375;
+const DEFAULT_CLUSTER_RADIUS: f64 = 50.0;
+
+/// Deserialises an `f64` field that defaults to [`DEFAULT_MINZOOM`].
+fn deserialize_minzoom<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_with_fallback(deserializer, DEFAULT_MINZOOM, "minzoom")
+}
+
+/// Deserialises an `f64` field that defaults to [`DEFAULT_MAXZOOM`].
+fn deserialize_maxzoom<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_with_fallback(deserializer, DEFAULT_MAXZOOM, "maxzoom")
+}
+
+/// Deserialises an `f64` field that defaults to [`DEFAULT_GEOJSON_MAXZOOM`].
+fn deserialize_geojson_maxzoom<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_with_fallback(deserializer, DEFAULT_GEOJSON_MAXZOOM, "maxzoom")
+}
+
+/// Deserialises an `f64` field that defaults to [`DEFAULT_TILE_SIZE`].
+fn deserialize_tile_size<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_with_fallback(deserializer, DEFAULT_TILE_SIZE, "tileSize")
+}
+
+/// Deserialises an `f64` field that defaults to [`DEFAULT_FACTOR`].
+fn deserialize_factor<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_with_fallback(deserializer, DEFAULT_FACTOR, "factor")
+}
+
+/// Deserialises an `f64` field that defaults to [`DEFAULT_BUFFER`].
+fn deserialize_buffer<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_with_fallback(deserializer, DEFAULT_BUFFER, "buffer")
+}
+
+/// Deserialises an `f64` field that defaults to [`DEFAULT_TOLERANCE`].
+fn deserialize_tolerance<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_with_fallback(deserializer, DEFAULT_TOLERANCE, "tolerance")
+}
+
+/// Deserialises an `f64` field that defaults to [`DEFAULT_CLUSTER_RADIUS`].
+fn deserialize_cluster_radius<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_f64_with_fallback(deserializer, DEFAULT_CLUSTER_RADIUS, "clusterRadius")
+}
+
+/// Deserialises a [`TileScheme`] field, falling back to `Default` on error.
+fn deserialize_tile_scheme_or_default<'de, D>(deserializer: D) -> Result<TileScheme, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(TileScheme::default()),
+        v => serde_json::from_value::<TileScheme>(v.clone()).or_else(|err| {
+            log::warn!("Invalid tile scheme {v}: {err}; using default");
+            Ok(TileScheme::default())
+        }),
+    }
+}
+
+/// Deserialises a [`VectorEncoding`] field, falling back to `Default` on error.
+fn deserialize_vector_encoding_or_default<'de, D>(
+    deserializer: D,
+) -> Result<VectorEncoding, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(VectorEncoding::default()),
+        v => serde_json::from_value::<VectorEncoding>(v.clone()).or_else(|err| {
+            log::warn!("Invalid vector encoding {v}: {err}; using default");
+            Ok(VectorEncoding::default())
+        }),
+    }
+}
+
+/// Deserialises a [`DemEncoding`] field, falling back to `Default` on error.
+fn deserialize_dem_encoding_or_default<'de, D>(deserializer: D) -> Result<DemEncoding, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(DemEncoding::default()),
+        v => serde_json::from_value::<DemEncoding>(v.clone()).or_else(|err| {
+            log::warn!("Invalid DEM encoding {v}: {err}; using default");
+            Ok(DemEncoding::default())
+        }),
+    }
+}
+
+/// Tile coordinate scheme.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TileScheme {
+    /// Slippy map tilenames scheme (default).
+    #[default]
+    Xyz,
+    /// OSGeo spec scheme.
+    Tms,
+}
+
+/// Encoding for vector tile sources.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum VectorEncoding {
+    /// Mapbox Vector Tiles (default).
+    #[default]
+    Mvt,
+    /// MapLibre Vector Tiles.
+    Mlt,
+}
+
+/// Encoding for raster DEM sources.
+#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DemEncoding {
+    /// Terrarium format PNG tiles.
+    Terrarium,
+    /// Mapbox Terrain RGB tiles (default).
+    #[default]
+    Mapbox,
+    /// Custom decoding using redFactor, blueFactor, greenFactor, baseShift.
+    Custom,
+}
+
+/// A vector tile source. Provides tiled vector data.
+///
+/// Either `url` (a TileJSON URL) or `tiles` must be provided.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct VectorSource {
+    /// A URL to a TileJSON resource.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    /// An array of one or more tile source URLs, as in the TileJSON spec.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tiles: Option<Vec<String>>,
+
+    /// Bounding box `[sw.lng, sw.lat, ne.lng, ne.lat]`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounds: Option<[f64; 4]>,
+
+    /// Tile coordinate scheme. Defaults to `xyz`.
+    #[serde(default, deserialize_with = "deserialize_tile_scheme_or_default")]
+    pub scheme: TileScheme,
+
+    /// Minimum zoom level for which tiles are available.
+    #[serde(default = "default_minzoom", deserialize_with = "deserialize_minzoom")]
+    pub minzoom: f64,
+
+    /// Maximum zoom level for which tiles are available.
+    #[serde(default = "default_maxzoom", deserialize_with = "deserialize_maxzoom")]
+    pub maxzoom: f64,
+
+    /// Attribution text to display when the map is shown to a user.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribution: Option<String>,
+
+    /// A property to use as a feature id (for feature state).
+    #[serde(rename = "promoteId", skip_serializing_if = "Option::is_none")]
+    pub promote_id: Option<Value>,
+
+    /// Whether the source's tiles are cached locally.
+    #[serde(default)]
+    pub volatile: bool,
+
+    /// The encoding used by this source.
+    #[serde(default, deserialize_with = "deserialize_vector_encoding_or_default")]
+    pub encoding: VectorEncoding,
+}
+
+/// A raster tile source. Provides tiled raster images.
+///
+/// Either `url` (a TileJSON URL) or `tiles` must be provided.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct RasterSource {
+    /// A URL to a TileJSON resource.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    /// An array of one or more tile source URLs, as in the TileJSON spec.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tiles: Option<Vec<String>>,
+
+    /// Bounding box `[sw.lng, sw.lat, ne.lng, ne.lat]`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounds: Option<[f64; 4]>,
+
+    /// Minimum zoom level for which tiles are available.
+    #[serde(default = "default_minzoom", deserialize_with = "deserialize_minzoom")]
+    pub minzoom: f64,
+
+    /// Maximum zoom level for which tiles are available.
+    #[serde(default = "default_maxzoom", deserialize_with = "deserialize_maxzoom")]
+    pub maxzoom: f64,
+
+    /// The minimum visual size to display tiles for this layer, in pixels.
+    #[serde(
+        rename = "tileSize",
+        default = "default_tile_size",
+        deserialize_with = "deserialize_tile_size"
+    )]
+    pub tile_size: f64,
+
+    /// Tile coordinate scheme. Defaults to `xyz`.
+    #[serde(default, deserialize_with = "deserialize_tile_scheme_or_default")]
+    pub scheme: TileScheme,
+
+    /// Attribution text to display when the map is shown to a user.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribution: Option<String>,
+
+    /// Whether the source's tiles are cached locally.
+    #[serde(default)]
+    pub volatile: bool,
+}
+
+/// A raster DEM (digital elevation model) source.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct RasterDemSource {
+    /// A URL to a TileJSON resource.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    /// An array of one or more tile source URLs, as in the TileJSON spec.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tiles: Option<Vec<String>>,
+
+    /// Bounding box `[sw.lng, sw.lat, ne.lng, ne.lat]`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounds: Option<[f64; 4]>,
+
+    /// Minimum zoom level for which tiles are available.
+    #[serde(default = "default_minzoom", deserialize_with = "deserialize_minzoom")]
+    pub minzoom: f64,
+
+    /// Maximum zoom level for which tiles are available.
+    #[serde(default = "default_maxzoom", deserialize_with = "deserialize_maxzoom")]
+    pub maxzoom: f64,
+
+    /// The minimum visual size to display tiles for this layer, in pixels.
+    #[serde(
+        rename = "tileSize",
+        default = "default_tile_size",
+        deserialize_with = "deserialize_tile_size"
+    )]
+    pub tile_size: f64,
+
+    /// Attribution text to display when the map is shown to a user.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribution: Option<String>,
+
+    /// The encoding used by this DEM source.
+    #[serde(default, deserialize_with = "deserialize_dem_encoding_or_default")]
+    pub encoding: DemEncoding,
+
+    /// Multiplied by the red channel value when decoding (custom encoding only).
+    #[serde(
+        rename = "redFactor",
+        default = "default_factor",
+        deserialize_with = "deserialize_factor"
+    )]
+    pub red_factor: f64,
+
+    /// Multiplied by the blue channel value when decoding (custom encoding only).
+    #[serde(
+        rename = "blueFactor",
+        default = "default_factor",
+        deserialize_with = "deserialize_factor"
+    )]
+    pub blue_factor: f64,
+
+    /// Multiplied by the green channel value when decoding (custom encoding only).
+    #[serde(
+        rename = "greenFactor",
+        default = "default_factor",
+        deserialize_with = "deserialize_factor"
+    )]
+    pub green_factor: f64,
+
+    /// Added to the encoding mix when decoding (custom encoding only).
+    #[serde(rename = "baseShift", default)]
+    pub base_shift: f64,
+
+    /// Whether the source's tiles are cached locally.
+    #[serde(default)]
+    pub volatile: bool,
+}
+
+/// A GeoJSON data source.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct GeoJsonSource {
+    /// A URL to a GeoJSON file, or inline GeoJSON.
+    pub data: Value,
+
+    /// Maximum zoom level at which to create vector tiles.
+    #[serde(
+        default = "default_geojson_maxzoom",
+        deserialize_with = "deserialize_geojson_maxzoom"
+    )]
+    pub maxzoom: f64,
+
+    /// Attribution text to display when the map is shown to a user.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribution: Option<String>,
+
+    /// Tile buffer size on each side (0–512).
+    #[serde(default = "default_buffer", deserialize_with = "deserialize_buffer")]
+    pub buffer: f64,
+
+    /// Douglas-Peucker simplification tolerance.
+    #[serde(
+        default = "default_tolerance",
+        deserialize_with = "deserialize_tolerance"
+    )]
+    pub tolerance: f64,
+
+    /// Whether to cluster point features by radius.
+    #[serde(default)]
+    pub cluster: bool,
+
+    /// Radius of each cluster if clustering is enabled.
+    #[serde(
+        rename = "clusterRadius",
+        default = "default_cluster_radius",
+        deserialize_with = "deserialize_cluster_radius"
+    )]
+    pub cluster_radius: f64,
+
+    /// Max zoom on which to cluster points.
+    #[serde(rename = "clusterMaxZoom", skip_serializing_if = "Option::is_none")]
+    pub cluster_max_zoom: Option<f64>,
+
+    /// Minimum number of points required to form a cluster.
+    #[serde(rename = "clusterMinPoints", skip_serializing_if = "Option::is_none")]
+    pub cluster_min_points: Option<f64>,
+
+    /// Custom aggregation properties on generated clusters.
+    #[serde(rename = "clusterProperties", skip_serializing_if = "Option::is_none")]
+    pub cluster_properties: Option<Value>,
+
+    /// Whether to calculate line distance metrics (required for `line-gradient`).
+    #[serde(rename = "lineMetrics", default)]
+    pub line_metrics: bool,
+
+    /// Whether to auto-assign feature ids based on array index.
+    #[serde(rename = "generateId", default)]
+    pub generate_id: bool,
+
+    /// A property to use as a feature id (for feature state).
+    #[serde(rename = "promoteId", skip_serializing_if = "Option::is_none")]
+    pub promote_id: Option<Value>,
+}
+
+/// A video data source.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct VideoSource {
+    /// URLs to video content in order of preferred format.
+    pub urls: Vec<String>,
+
+    /// Corners of the video specified as `[[lng, lat]; 4]`.
+    pub coordinates: [[f64; 2]; 4],
+}
+
+/// An image data source.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct ImageSource {
+    /// URL pointing to the image.
+    pub url: String,
+
+    /// Corners of the image specified as `[[lng, lat]; 4]`.
+    pub coordinates: [[f64; 2]; 4],
+}
+
+/// A map data source — one of the supported source types.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(tag = "type")]
+pub enum Source {
+    /// A vector tile source.
+    #[serde(rename = "vector")]
+    Vector(VectorSource),
+    /// A raster tile source.
+    #[serde(rename = "raster")]
+    Raster(RasterSource),
+    /// A raster DEM source.
+    #[serde(rename = "raster-dem")]
+    RasterDem(RasterDemSource),
+    /// A GeoJSON data source.
+    #[serde(rename = "geojson")]
+    GeoJson(GeoJsonSource),
+    /// A video data source.
+    #[serde(rename = "video")]
+    Video(VideoSource),
+    /// An image data source.
+    #[serde(rename = "image")]
+    Image(ImageSource),
+}
+
+fn default_minzoom() -> f64 {
+    DEFAULT_MINZOOM
+}
+fn default_maxzoom() -> f64 {
+    DEFAULT_MAXZOOM
+}
+fn default_tile_size() -> f64 {
+    DEFAULT_TILE_SIZE
+}
+fn default_factor() -> f64 {
+    DEFAULT_FACTOR
+}
+fn default_geojson_maxzoom() -> f64 {
+    DEFAULT_GEOJSON_MAXZOOM
+}
+fn default_buffer() -> f64 {
+    DEFAULT_BUFFER
+}
+fn default_tolerance() -> f64 {
+    DEFAULT_TOLERANCE
+}
+fn default_cluster_radius() -> f64 {
+    DEFAULT_CLUSTER_RADIUS
+}
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn parse_vector_source_with_url() {
+        let json = r#"{
+            "type": "vector",
+            "url": "https://example.com/tiles.json",
+            "attribution": "© Example"
+        }"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::Vector(v) = source else {
+            panic!("expected Vector source");
+        };
+        assert_eq!(v.url.as_deref(), Some("https://example.com/tiles.json"));
+        assert_eq!(v.attribution.as_deref(), Some("© Example"));
+        assert_eq!(v.minzoom, DEFAULT_MINZOOM);
+        assert_eq!(v.maxzoom, DEFAULT_MAXZOOM);
+        assert_eq!(v.scheme, TileScheme::Xyz);
+        assert_eq!(v.encoding, VectorEncoding::Mvt);
+    }
+
+    #[test]
+    fn parse_vector_source_with_tiles() {
+        let json = r#"{
+            "type": "vector",
+            "tiles": ["https://a.example.com/{z}/{x}/{y}.pbf"],
+            "maxzoom": 14,
+            "scheme": "tms"
+        }"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::Vector(v) = source else {
+            panic!("expected Vector source");
+        };
+        assert_eq!(
+            v.tiles,
+            Some(vec!["https://a.example.com/{z}/{x}/{y}.pbf".to_string()])
+        );
+        assert_eq!(v.maxzoom, 14.0);
+        assert_eq!(v.scheme, TileScheme::Tms);
+    }
+
+    #[test]
+    fn parse_raster_source() {
+        let json = r#"{
+            "type": "raster",
+            "tiles": ["https://example.com/{z}/{x}/{y}.png"],
+            "tileSize": 256
+        }"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::Raster(r) = source else {
+            panic!("expected Raster source");
+        };
+        assert_eq!(r.tile_size, 256.0);
+        assert_eq!(r.scheme, TileScheme::Xyz);
+    }
+
+    #[test]
+    fn parse_raster_dem_source() {
+        let json = r#"{
+            "type": "raster-dem",
+            "url": "https://example.com/dem.json",
+            "encoding": "terrarium"
+        }"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::RasterDem(d) = source else {
+            panic!("expected RasterDem source");
+        };
+        assert_eq!(d.encoding, DemEncoding::Terrarium);
+        assert_eq!(d.red_factor, DEFAULT_FACTOR);
+    }
+
+    #[test]
+    fn parse_geojson_source() {
+        let json = r#"{
+            "type": "geojson",
+            "data": "https://example.com/data.geojson",
+            "cluster": true,
+            "clusterRadius": 80
+        }"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::GeoJson(g) = source else {
+            panic!("expected GeoJson source");
+        };
+        assert!(g.cluster);
+        assert_eq!(g.cluster_radius, 80.0);
+        assert_eq!(g.tolerance, DEFAULT_TOLERANCE);
+    }
+
+    #[test]
+    fn parse_video_source() {
+        let json = r#"{
+            "type": "video",
+            "urls": ["https://example.com/video.mp4"],
+            "coordinates": [
+                [-122.51596391201019, 37.56238816766053],
+                [-122.51467645168304, 37.56410183312965],
+                [-122.51309394836426, 37.563391708549425],
+                [-122.51423120498657, 37.56161849366671]
+            ]
+        }"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::Video(v) = source else {
+            panic!("expected Video source");
+        };
+        assert_eq!(v.urls, vec!["https://example.com/video.mp4"]);
+    }
+
+    #[test]
+    fn parse_image_source() {
+        let json = r#"{
+            "type": "image",
+            "url": "https://example.com/image.png",
+            "coordinates": [
+                [-80.425, 46.437],
+                [-71.516, 46.437],
+                [-71.516, 37.936],
+                [-80.425, 37.936]
+            ]
+        }"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::Image(i) = source else {
+            panic!("expected Image source");
+        };
+        assert_eq!(i.url, "https://example.com/image.png");
+    }
+
+    #[test]
+    fn unknown_source_type_returns_error() {
+        let json = r#"{"type": "unknown"}"#;
+        assert!(serde_json::from_str::<Source>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_sources_map_skips_invalid() {
+        let json = r#"{
+            "good": {"type": "vector", "url": "https://example.com/tiles.json"},
+            "bad":  {"type": "not-a-real-type"}
+        }"#;
+        let mut map: HashMap<String, serde_json::Value> = serde_json::from_str(json).unwrap();
+        // Test the helper via a manual iteration (mirrors what deserialize_sources does)
+        let mut out = HashMap::new();
+        for (key, val) in map.drain() {
+            if let Ok(s) = serde_json::from_value::<Source>(val) {
+                out.insert(key, s);
+            }
+        }
+        assert!(out.contains_key("good"));
+        assert!(!out.contains_key("bad"));
+    }
+
+    #[test]
+    fn parse_maptiler_sources() {
+        // Matches the sources block from the maptiler_fmt.json fixture.
+        let json = r#"{
+            "maptiler_attribution": {
+                "attribution": "<a href=\"https://www.maptiler.com/copyright/\">© MapTiler</a>",
+                "type": "vector"
+            },
+            "maptiler_planet": {
+                "url": "https://api.maptiler.com/tiles/v3/tiles.json?key=xxx",
+                "type": "vector"
+            }
+        }"#;
+        let mut map: HashMap<String, serde_json::Value> = serde_json::from_str(json).unwrap();
+        let mut out = HashMap::new();
+        for (key, val) in map.drain() {
+            if let Ok(s) = serde_json::from_value::<Source>(val) {
+                out.insert(key, s);
+            }
+        }
+        assert_eq!(out.len(), 2);
+        let Source::Vector(planet) = &out["maptiler_planet"] else {
+            panic!("expected vector");
+        };
+        assert_eq!(
+            planet.url.as_deref(),
+            Some("https://api.maptiler.com/tiles/v3/tiles.json?key=xxx")
+        );
+    }
+
+    #[test]
+    fn invalid_minzoom_falls_back_to_default() {
+        let json = r#"{"type": "vector", "url": "https://example.com/t.json", "minzoom": "bad"}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::Vector(v) = source else {
+            panic!("expected Vector")
+        };
+        assert_eq!(v.minzoom, DEFAULT_MINZOOM);
+    }
+
+    #[test]
+    fn invalid_maxzoom_falls_back_to_default() {
+        let json = r#"{"type": "raster", "tiles": ["https://example.com/{z}/{x}/{y}.png"], "maxzoom": "bad"}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::Raster(r) = source else {
+            panic!("expected Raster")
+        };
+        assert_eq!(r.maxzoom, DEFAULT_MAXZOOM);
+    }
+
+    #[test]
+    fn invalid_tile_size_falls_back_to_default() {
+        let json = r#"{"type": "raster", "tiles": ["https://example.com/{z}/{x}/{y}.png"], "tileSize": [512]}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::Raster(r) = source else {
+            panic!("expected Raster")
+        };
+        assert_eq!(r.tile_size, DEFAULT_TILE_SIZE);
+    }
+
+    #[test]
+    fn invalid_scheme_falls_back_to_default() {
+        let json =
+            r#"{"type": "vector", "url": "https://example.com/t.json", "scheme": "not-a-scheme"}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::Vector(v) = source else {
+            panic!("expected Vector")
+        };
+        assert_eq!(v.scheme, TileScheme::Xyz);
+    }
+
+    #[test]
+    fn invalid_vector_encoding_falls_back_to_default() {
+        let json = r#"{"type": "vector", "url": "https://example.com/t.json", "encoding": 42}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::Vector(v) = source else {
+            panic!("expected Vector")
+        };
+        assert_eq!(v.encoding, VectorEncoding::Mvt);
+    }
+
+    #[test]
+    fn invalid_dem_encoding_falls_back_to_default() {
+        let json =
+            r#"{"type": "raster-dem", "url": "https://example.com/dem.json", "encoding": "bogus"}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::RasterDem(d) = source else {
+            panic!("expected RasterDem")
+        };
+        assert_eq!(d.encoding, DemEncoding::Mapbox);
+    }
+
+    #[test]
+    fn invalid_red_factor_falls_back_to_default() {
+        let json =
+            r#"{"type": "raster-dem", "url": "https://example.com/dem.json", "redFactor": "x"}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::RasterDem(d) = source else {
+            panic!("expected RasterDem")
+        };
+        assert_eq!(d.red_factor, DEFAULT_FACTOR);
+    }
+
+    #[test]
+    fn invalid_buffer_falls_back_to_default() {
+        let json = r#"{"type": "geojson", "data": "https://example.com/d.json", "buffer": "wide"}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::GeoJson(g) = source else {
+            panic!("expected GeoJson")
+        };
+        assert_eq!(g.buffer, DEFAULT_BUFFER);
+    }
+
+    #[test]
+    fn invalid_tolerance_falls_back_to_default() {
+        let json =
+            r#"{"type": "geojson", "data": "https://example.com/d.json", "tolerance": null}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::GeoJson(g) = source else {
+            panic!("expected GeoJson")
+        };
+        assert_eq!(g.tolerance, DEFAULT_TOLERANCE);
+    }
+
+    #[test]
+    fn invalid_cluster_radius_falls_back_to_default() {
+        let json =
+            r#"{"type": "geojson", "data": "https://example.com/d.json", "clusterRadius": "big"}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::GeoJson(g) = source else {
+            panic!("expected GeoJson")
+        };
+        assert_eq!(g.cluster_radius, DEFAULT_CLUSTER_RADIUS);
+    }
+
+    #[test]
+    fn invalid_geojson_maxzoom_falls_back_to_default() {
+        let json =
+            r#"{"type": "geojson", "data": "https://example.com/d.json", "maxzoom": "high"}"#;
+        let source: Source = serde_json::from_str(json).unwrap();
+        let Source::GeoJson(g) = source else {
+            panic!("expected GeoJson")
+        };
+        assert_eq!(g.maxzoom, DEFAULT_GEOJSON_MAXZOOM);
+    }
+}

--- a/galileo-maplibre/src/style/value.rs
+++ b/galileo-maplibre/src/style/value.rs
@@ -1,0 +1,686 @@
+//! Generic property value types for MapLibre style layers.
+//!
+//! Every paint and layout property in the MapLibre style specification has a
+//! **known output type** — for example `line-color` always produces a color,
+//! `line-width` always produces a number, and `text-optional` always produces
+//! a boolean.  The JSON representation of that value can take three forms:
+//!
+//! 1. **Literal** — a plain JSON primitive already of the correct type
+//!    (e.g. `"#ff0000"` for color, `2.0` for number, `true` for bool).
+//! 2. **Expression** — a JSON array whose first element is an operator string
+//!    (e.g. `["interpolate", ["linear"], ["zoom"], 5, 1, 10, 4]`).
+//!    Expressions are the modern (post-v0.41.0) way to compute a value from
+//!    map state (zoom level) or feature properties.
+//! 3. **Function** — a JSON object with a `"stops"` key (and optionally
+//!    `"base"`, `"property"`, `"type"`, `"default"`, `"colorSpace"`).
+//!    Functions are the legacy (pre-v0.41.0) equivalent of expressions and
+//!    are deprecated but still widely used in real-world styles.
+//!
+//! # Type parameters
+//!
+//! [`StyleValue<T>`] is generic over the output type `T`.  The concrete
+//! instantiations used across layer properties are:
+//!
+//! | Rust type | MapLibre spec type | JSON representation |
+//! |-----------|-------------------|---------------------|
+//! | [`f64`]   | `number`          | JSON number         |
+//! | [`bool`]  | `boolean`         | JSON boolean        |
+//! | [`String`]| `string`          | JSON string         |
+//! | [`Color`] | `color`           | JSON string         |
+//!
+//! # Serde strategy
+//!
+//! `StyleValue<T>` is deserialized with `#[serde(untagged)]`.  Serde tries
+//! each variant in order:
+//! - `Literal(T)` — succeeds when the JSON is a primitive that directly
+//!   deserializes as `T` (number → `f64`, string → `Color`/`String`, bool →
+//!   `bool`).
+//! - `Expression(Expr)` — succeeds when the JSON is an array.
+//! - `Function(Function<T>)` — succeeds when the JSON is an object (it
+//!   must have a `"stops"` key; other objects are an error).
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::expression::Expr;
+
+/// A MapLibre color value.
+///
+/// Colors appear in the JSON as strings in one of several CSS-compatible
+/// formats: hex (`#rrggbb`, `#rgb`, `#rrggbbaa`), `rgb(r,g,b)`,
+/// `rgba(r,g,b,a)`, `hsl(h,s%,l%)`, `hsla(h,s%,l%,a)`, or a named CSS
+/// color keyword such as `"red"`.
+///
+/// This type stores the original string verbatim.  Parsing to RGBA components
+/// is the responsibility of the renderer and is not performed here.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Color(pub String);
+
+impl Color {
+    /// Create a `Color` from any string-like value.
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Borrow the underlying color string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Color {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for Color {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl From<String> for Color {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+/// The interpolation type for a legacy [`Function`].
+///
+/// Governs how the function interpolates between stops.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FunctionType {
+    /// Passes the input through unchanged (no stops required).
+    Identity,
+    /// Interpolates exponentially between stops (default for numeric output).
+    Exponential,
+    /// Returns the output of the nearest stop below the input.
+    Interval,
+    /// Returns the output for the stop whose input equals the feature value.
+    Categorical,
+}
+
+/// The color space used for interpolating color outputs in a legacy [`Function`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ColorSpace {
+    /// Interpolate in RGB color space.
+    Rgb,
+    /// Interpolate in CIELAB color space.
+    Lab,
+    /// Interpolate in Hue-Chroma-Luminance color space.
+    Hcl,
+}
+
+/// A single stop in a legacy [`Function`].
+///
+/// A stop maps an input value (zoom level or feature property value) to an
+/// output value of type `T`.  Both are stored as raw [`Value`] because:
+/// - The input can be a plain number *or* a `{"zoom": N, "value": V}` object
+///   (for zoom-and-property functions).
+/// - The output must be appropriate for `T` but is easier to keep as raw JSON
+///   here and let the renderer coerce it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FunctionStop {
+    /// The input threshold — a zoom level (`number`) or a zoom-and-property
+    /// object (`{"zoom": number, "value": any}`).
+    pub input: Value,
+    /// The output value at this stop.
+    pub output: Value,
+}
+
+// Custom deserialization: stops are `[input, output]` arrays in JSON.
+mod function_stops_serde {
+    use std::fmt;
+
+    use serde::de::{SeqAccess, Visitor};
+    use serde::{Deserializer, Serializer};
+    use serde_json::Value;
+
+    use super::FunctionStop;
+
+    pub fn serialize<S>(stops: &Vec<FunctionStop>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = s.serialize_seq(Some(stops.len()))?;
+        for stop in stops {
+            seq.serialize_element(&[&stop.input, &stop.output])?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Vec<FunctionStop>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StopsVisitor;
+
+        impl<'de> Visitor<'de> for StopsVisitor {
+            type Value = Vec<FunctionStop>;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("an array of [input, output] stop pairs")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut stops = Vec::new();
+                while let Some(pair) = seq.next_element::<[Value; 2]>()? {
+                    let [input, output] = pair;
+                    stops.push(FunctionStop { input, output });
+                }
+                Ok(stops)
+            }
+        }
+
+        d.deserialize_seq(StopsVisitor)
+    }
+}
+
+/// A legacy MapLibre zoom/property function (deprecated since v0.41.0).
+///
+/// Still widely used in real-world styles.  The renderer evaluates this at
+/// runtime by interpolating between stops to produce a value of type `T`.
+///
+/// # JSON shape
+/// ```json
+/// {"stops": [[5, 1], [10, 4]]}
+/// {"base": 1.4, "stops": [[5, 1], [10, 4]]}
+/// {"property": "temperature", "stops": [[0, "blue"], [100, "red"]]}
+/// {"base": 1, "stops": [[{"zoom": 0, "value": 0}, 0], [{"zoom": 20, "value": 5}, 20]]}
+/// ```
+///
+/// The `default` and `stops` outputs carry raw [`Value`] rather than `T`
+/// because the stop output type can only be verified by the renderer at
+/// runtime (e.g. for `identity` functions, the type is not statically known).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Function {
+    /// The stop pairs `[input, output]`.  Required for all types except
+    /// `identity`.
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        with = "function_stops_serde"
+    )]
+    pub stops: Vec<FunctionStop>,
+
+    /// The exponential base for `exponential` interpolation.  Default is `1`
+    /// (linear).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<f64>,
+
+    /// The feature property to use as the function input.  If absent, the
+    /// function input is the current zoom level.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub property: Option<String>,
+
+    /// The interpolation type.  Defaults to `exponential` for numeric
+    /// properties and `interval` for others.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub function_type: Option<FunctionType>,
+
+    /// Fallback output value used when the input does not match any stop or
+    /// when the feature property is missing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<Value>,
+
+    /// Color space for interpolating color outputs.
+    #[serde(rename = "colorSpace", skip_serializing_if = "Option::is_none")]
+    pub color_space: Option<ColorSpace>,
+}
+
+/// A style property value that ultimately produces a `T`.
+///
+/// See the [module documentation](self) for the full design rationale.
+///
+/// # Deserialization
+///
+/// ```json
+/// // Literal f64
+/// 2.0
+///
+/// // Literal Color
+/// "#ff0000"
+///
+/// // Expression (modern) — JSON array starting with an operator string
+/// ["interpolate", ["linear"], ["zoom"], 5, 1, 10, 4]
+///
+/// // Function (legacy) — JSON object with a "stops" key
+/// {"base": 1.4, "stops": [[5, 1], [10, 4]]}
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum StyleValue<T> {
+    /// A literal value of the expected type, present directly in the JSON.
+    Literal(T),
+    /// A modern expression: a JSON array whose first element is an operator
+    /// string.  The renderer evaluates this at runtime to produce a `T`.
+    Expression(Expr),
+    /// A legacy zoom/property function: a JSON object with a `"stops"` key.
+    /// The renderer evaluates this at runtime to produce a `T`.
+    Function(Function),
+}
+
+impl<T> StyleValue<T> {
+    /// Returns `true` if this is a [`StyleValue::Literal`].
+    pub fn is_literal(&self) -> bool {
+        matches!(self, Self::Literal(_))
+    }
+
+    /// Returns the literal value, or `None` if this is not a literal.
+    pub fn as_literal(&self) -> Option<&T> {
+        match self {
+            Self::Literal(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if this is a [`StyleValue::Expression`].
+    pub fn is_expression(&self) -> bool {
+        matches!(self, Self::Expression(_))
+    }
+
+    /// Returns the expression, or `None` if this is not an expression.
+    pub fn as_expression(&self) -> Option<&Expr> {
+        match self {
+            Self::Expression(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if this is a [`StyleValue::Function`].
+    pub fn is_function(&self) -> bool {
+        matches!(self, Self::Function(_))
+    }
+
+    /// Returns the function, or `None` if this is not a function.
+    pub fn as_function(&self) -> Option<&Function> {
+        match self {
+            Self::Function(f) => Some(f),
+            _ => None,
+        }
+    }
+}
+
+impl From<f64> for StyleValue<f64> {
+    fn from(v: f64) -> Self {
+        Self::Literal(v)
+    }
+}
+
+impl From<bool> for StyleValue<bool> {
+    fn from(v: bool) -> Self {
+        Self::Literal(v)
+    }
+}
+
+impl From<String> for StyleValue<String> {
+    fn from(v: String) -> Self {
+        Self::Literal(v)
+    }
+}
+
+impl From<&str> for StyleValue<String> {
+    fn from(v: &str) -> Self {
+        Self::Literal(v.to_owned())
+    }
+}
+
+impl From<Color> for StyleValue<Color> {
+    fn from(v: Color) -> Self {
+        Self::Literal(v)
+    }
+}
+
+impl<'a> From<&'a str> for StyleValue<Color> {
+    fn from(v: &'a str) -> Self {
+        Self::Literal(Color::from(v))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn color_from_hex() {
+        let c = Color::from("#ff0000");
+        assert_eq!(c.as_str(), "#ff0000");
+        assert_eq!(c.to_string(), "#ff0000");
+    }
+
+    #[test]
+    fn color_from_rgb() {
+        let c = Color::new("rgb(255,0,0)");
+        assert_eq!(c.as_str(), "rgb(255,0,0)");
+    }
+
+    #[test]
+    fn color_from_hsl() {
+        let c = Color::new("hsl(47,79%,94%)");
+        assert_eq!(c.as_str(), "hsl(47,79%,94%)");
+    }
+
+    #[test]
+    fn color_from_named() {
+        let c = Color::from("red");
+        assert_eq!(c.as_str(), "red");
+    }
+
+    #[test]
+    fn color_serde_roundtrip() {
+        let c = Color::from("#aabbcc");
+        let json = serde_json::to_string(&c).unwrap();
+        assert_eq!(json, "\"#aabbcc\"");
+        let back: Color = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn expression_operator_and_args() {
+        let e: Expr =
+            serde_json::from_value(json!(["interpolate", ["linear"], ["zoom"], 5, 1, 10, 4]))
+                .unwrap();
+        assert_eq!(e.operator(), Some("interpolate"));
+        // Interpolate with 2 stops
+        assert!(matches!(e, Expr::Interpolate { ref stops, .. } if stops.len() == 2));
+    }
+
+    #[test]
+    fn expression_step_operator() {
+        let e: Expr =
+            serde_json::from_value(json!(["step", ["zoom"], 0.5, 12, 1.0, 15, 2.0])).unwrap();
+        assert_eq!(e.operator(), Some("step"));
+    }
+
+    #[test]
+    fn expression_roundtrip() {
+        // Round-trip via StyleValue so we verify end-to-end serde
+        let original = json!(["interpolate", ["linear"], ["zoom"], 5, 1.0, 10, 4.0]);
+        let v: StyleValue<f64> = serde_json::from_value(original.clone()).unwrap();
+        assert!(v.is_expression());
+        assert_eq!(
+            v.as_expression().and_then(|e| e.operator()),
+            Some("interpolate")
+        );
+    }
+
+    #[test]
+    fn function_stops_only() {
+        let f: Function = serde_json::from_value(json!({"stops": [[5, 1.0], [10, 4.0]]})).unwrap();
+        assert_eq!(f.stops.len(), 2);
+        assert_eq!(f.stops[0].input, json!(5));
+        assert_eq!(f.stops[0].output, json!(1.0));
+        assert!(f.base.is_none());
+        assert!(f.property.is_none());
+        assert!(f.function_type.is_none());
+        assert!(f.default.is_none());
+        assert!(f.color_space.is_none());
+    }
+
+    #[test]
+    fn function_with_base() {
+        let f: Function =
+            serde_json::from_value(json!({"base": 1.4, "stops": [[5, 1.0], [10, 4.0]]})).unwrap();
+        assert_eq!(f.base, Some(1.4));
+        assert_eq!(f.stops.len(), 2);
+    }
+
+    #[test]
+    fn function_with_property() {
+        let f: Function = serde_json::from_value(json!({
+            "property": "temperature",
+            "stops": [[0, "blue"], [100, "red"]]
+        }))
+        .unwrap();
+        assert_eq!(f.property.as_deref(), Some("temperature"));
+        assert_eq!(f.stops[0].output, json!("blue"));
+    }
+
+    #[test]
+    fn function_with_type_and_colorspace() {
+        let f: Function = serde_json::from_value(json!({
+            "type": "exponential",
+            "colorSpace": "lab",
+            "stops": [[0, "#fff"], [10, "#000"]]
+        }))
+        .unwrap();
+        assert_eq!(f.function_type, Some(FunctionType::Exponential));
+        assert_eq!(f.color_space, Some(ColorSpace::Lab));
+    }
+
+    #[test]
+    fn function_with_default() {
+        let f: Function = serde_json::from_value(json!({
+            "stops": [[0, 1.0]],
+            "default": 0.5
+        }))
+        .unwrap();
+        assert_eq!(f.default, Some(json!(0.5)));
+    }
+
+    #[test]
+    fn function_color_stops() {
+        let f: Function = serde_json::from_value(
+            json!({"stops": [[6, "hsl(47,79%,94%)"], [14, "hsl(42,49%,93%)"]]}),
+        )
+        .unwrap();
+        assert_eq!(f.stops.len(), 2);
+        assert_eq!(f.stops[0].input, json!(6));
+        assert_eq!(f.stops[0].output, json!("hsl(47,79%,94%)"));
+    }
+
+    #[test]
+    fn function_roundtrip() {
+        let original = json!({"base": 1.5, "stops": [[0, "#fff"], [10, "#000"]]});
+        let f: Function = serde_json::from_value(original.clone()).unwrap();
+        let back = serde_json::to_value(&f).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn function_type_variants() {
+        for (s, expected) in [
+            ("identity", FunctionType::Identity),
+            ("exponential", FunctionType::Exponential),
+            ("interval", FunctionType::Interval),
+            ("categorical", FunctionType::Categorical),
+        ] {
+            let f: Function =
+                serde_json::from_value(json!({"type": s, "stops": [[0, 1]]})).unwrap();
+            assert_eq!(f.function_type, Some(expected));
+        }
+    }
+
+    #[test]
+    fn f64_literal() {
+        let v: StyleValue<f64> = serde_json::from_value(json!(2.0)).unwrap();
+        assert!(v.is_literal());
+        assert_eq!(v.as_literal(), Some(&2.0));
+        assert!(!v.is_expression());
+        assert!(!v.is_function());
+    }
+
+    #[test]
+    fn f64_expression() {
+        let raw = json!(["interpolate", ["linear"], ["zoom"], 5, 1.0, 10, 4.0]);
+        let v: StyleValue<f64> = serde_json::from_value(raw).unwrap();
+        assert!(v.is_expression());
+        assert_eq!(
+            v.as_expression().and_then(|e| e.operator()),
+            Some("interpolate")
+        );
+        assert!(!v.is_literal());
+        assert!(!v.is_function());
+    }
+
+    #[test]
+    fn f64_function() {
+        let raw = json!({"base": 1.4, "stops": [[5, 1.0], [10, 4.0]]});
+        let v: StyleValue<f64> = serde_json::from_value(raw).unwrap();
+        assert!(v.is_function());
+        assert_eq!(v.as_function().and_then(|f| f.base), Some(1.4));
+        assert!(!v.is_literal());
+        assert!(!v.is_expression());
+    }
+
+    #[test]
+    fn f64_step_expression() {
+        let v: StyleValue<f64> =
+            serde_json::from_value(json!(["step", ["zoom"], 0.5, 12, 1.0, 15, 2.0])).unwrap();
+        assert_eq!(v.as_expression().and_then(|e| e.operator()), Some("step"));
+    }
+
+    #[test]
+    fn bool_literal_true() {
+        let v: StyleValue<bool> = serde_json::from_value(json!(true)).unwrap();
+        assert_eq!(v.as_literal(), Some(&true));
+    }
+
+    #[test]
+    fn bool_literal_false() {
+        let v: StyleValue<bool> = serde_json::from_value(json!(false)).unwrap();
+        assert_eq!(v.as_literal(), Some(&false));
+    }
+
+    #[test]
+    fn bool_expression() {
+        let v: StyleValue<bool> = serde_json::from_value(json!(["has", "name"])).unwrap();
+        assert!(v.is_expression());
+        assert_eq!(v.as_expression().and_then(|e| e.operator()), Some("has"));
+    }
+
+    #[test]
+    fn string_literal() {
+        let v: StyleValue<String> = serde_json::from_value(json!("butt")).unwrap();
+        assert_eq!(v.as_literal(), Some(&"butt".to_owned()));
+    }
+
+    #[test]
+    fn string_expression() {
+        let v: StyleValue<String> = serde_json::from_value(json!(["get", "name"])).unwrap();
+        assert!(v.is_expression());
+        assert_eq!(v.as_expression().and_then(|e| e.operator()), Some("get"));
+    }
+
+    #[test]
+    fn color_literal_hex() {
+        let v: StyleValue<Color> = serde_json::from_value(json!("#ff0000")).unwrap();
+        assert_eq!(v.as_literal(), Some(&Color::from("#ff0000")));
+    }
+
+    #[test]
+    fn color_literal_hsl() {
+        let v: StyleValue<Color> = serde_json::from_value(json!("hsl(47,79%,94%)")).unwrap();
+        assert_eq!(v.as_literal().map(|c| c.as_str()), Some("hsl(47,79%,94%)"));
+    }
+
+    #[test]
+    fn color_expression() {
+        let v: StyleValue<Color> = serde_json::from_value(json!([
+            "match",
+            ["get", "class"],
+            "residential",
+            "#f00",
+            "#000"
+        ]))
+        .unwrap();
+        assert!(v.is_expression());
+        assert_eq!(v.as_expression().and_then(|e| e.operator()), Some("match"));
+    }
+
+    #[test]
+    fn color_function_stops() {
+        let raw = json!({"stops": [[6, "hsl(47,79%,94%)"], [14, "hsl(42,49%,93%)"]]});
+        let v: StyleValue<Color> = serde_json::from_value(raw).unwrap();
+        assert!(v.is_function());
+        let f = v.as_function().unwrap();
+        assert_eq!(f.stops.len(), 2);
+        assert_eq!(f.stops[0].output, json!("hsl(47,79%,94%)"));
+    }
+
+    #[test]
+    fn color_function_with_base() {
+        let raw = json!({"base": 1.0, "stops": [[6, "hsl(47,79%,94%)"], [14, "#aaa"]]});
+        let v: StyleValue<Color> = serde_json::from_value(raw).unwrap();
+        let f = v.as_function().unwrap();
+        assert_eq!(f.base, Some(1.0));
+    }
+
+    #[test]
+    fn maptiler_background_color_function() {
+        // From maptiler_fmt.json — background-color with zoom stops
+        let raw = json!({"stops": [[6, "hsl(47,79%,94%)"], [14, "hsl(42,49%,93%)"]]});
+        let v: StyleValue<Color> = serde_json::from_value(raw).unwrap();
+        let f = v.as_function().unwrap();
+        assert_eq!(f.stops[0].input, json!(6));
+        assert_eq!(f.stops[1].input, json!(14));
+    }
+
+    #[test]
+    fn maptiler_fill_opacity_function() {
+        // From maptiler_fmt.json — fill-opacity with zoom stops
+        let raw = json!({"stops": [[0, 1], [8, 0.1]]});
+        let v: StyleValue<f64> = serde_json::from_value(raw).unwrap();
+        let f = v.as_function().unwrap();
+        assert_eq!(f.stops[0].output, json!(1));
+        assert_eq!(f.stops[1].output, json!(0.1));
+    }
+
+    #[test]
+    fn roundtrip_f64_literal() {
+        let original = json!(1.5);
+        let v: StyleValue<f64> = serde_json::from_value(original.clone()).unwrap();
+        let back = serde_json::to_value(&v).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn roundtrip_color_literal() {
+        let original = json!("#aabbcc");
+        let v: StyleValue<Color> = serde_json::from_value(original.clone()).unwrap();
+        let back = serde_json::to_value(&v).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn roundtrip_expression() {
+        let original = json!(["interpolate", ["linear"], ["zoom"], 5, 1.0, 10, 4.0]);
+        let v: StyleValue<f64> = serde_json::from_value(original.clone()).unwrap();
+        let back = serde_json::to_value(&v).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn roundtrip_function() {
+        let original = json!({"base": 1.5, "stops": [[0, "#fff"], [10, "#000"]]});
+        let v: StyleValue<Color> = serde_json::from_value(original.clone()).unwrap();
+        let back = serde_json::to_value(&v).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn from_impls() {
+        assert_eq!(StyleValue::from(2.5_f64).as_literal(), Some(&2.5));
+        assert_eq!(StyleValue::from(true).as_literal(), Some(&true));
+        assert_eq!(
+            StyleValue::from("butt").as_literal(),
+            Some(&"butt".to_owned())
+        );
+        assert_eq!(
+            StyleValue::from(Color::from("red")).as_literal(),
+            Some(&Color::from("red"))
+        );
+        // &str → StyleValue<Color>
+        let sc: StyleValue<Color> = StyleValue::from("blue");
+        assert_eq!(sc.as_literal(), Some(&Color::from("blue")));
+    }
+}


### PR DESCRIPTION
This PR is the first step towards a `MaplibreLayer` that will allow adding maplibre (and mapbox) maps to Galileo with one-line command.

It contains implementation of the maplibre style JSON parser, converting it to strongly typed Rust structures. The next step will be to convert these definitions into Galileo layers.

Relates to #280 