### PR TITLE
feat: Draw vt features in the order of style rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ csv = "1.3"
 egui = "0.33"
 egui-wgpu = "0.33"
 eframe = { version = "0.33", default-features = false }
+either = "1"
 env_logger = "0.11"
 fontdb = { version = "0.23", default-features = false }
 font-kit = "0.14"

--- a/galileo/Cargo.toml
+++ b/galileo/Cargo.toml
@@ -30,6 +30,7 @@ base64 = { workspace = true }
 bytemuck = { workspace = true, features = ["derive"] }
 bytes = { workspace = true }
 cfg-if = { workspace = true }
+either = { workspace = true }
 futures-intrusive = { workspace = true }
 galileo-mvt = { workspace = true }
 galileo-types = { workspace = true }

--- a/galileo/src/layer/vector_tile_layer/style.rs
+++ b/galileo/src/layer/vector_tile_layer/style.rs
@@ -1,6 +1,6 @@
 //! See [`VectorTileStyle`].
 
-use galileo_mvt::{MvtFeature, MvtGeometry};
+use galileo_mvt::MvtFeature;
 use serde::{Deserialize, Serialize};
 
 use crate::Color;
@@ -25,81 +25,6 @@ pub struct VectorTileStyle {
     pub background: StyleValue<Color>,
 }
 
-impl VectorTileStyle {
-    /// Get a rule for the given feature.
-    pub fn get_style_rule(
-        &self,
-        layer_name: &str,
-        resolution: f64,
-        feature: &MvtFeature,
-    ) -> Option<&StyleRule> {
-        self.rules.iter().find(|&rule| {
-            let correct_geometry_type = match feature.geometry {
-                MvtGeometry::Point(_)
-                    if matches!(
-                        rule.symbol,
-                        VectorTileSymbol::Point(_) | VectorTileSymbol::Label(_)
-                    ) =>
-                {
-                    true
-                }
-                MvtGeometry::LineString(_) if matches!(rule.symbol, VectorTileSymbol::Line(_)) => {
-                    true
-                }
-                MvtGeometry::Polygon(_) if matches!(rule.symbol, VectorTileSymbol::Polygon(_)) => {
-                    true
-                }
-                _ => false,
-            };
-
-            if !correct_geometry_type {
-                return false;
-            }
-
-            if rule.layer_name.as_ref().is_some_and(|v| v != layer_name) {
-                return false;
-            }
-            if rule.max_resolution.is_some_and(|v| v < resolution) {
-                return false;
-            }
-            if rule.min_resolution.is_some_and(|v| v > resolution) {
-                return false;
-            }
-
-            rule.properties.iter().all(|filter| {
-                let value = feature.properties.get(&filter.property_name);
-                match (&filter.operator, value) {
-                    (PropertyFilterOperator::Equal(value), Some(v)) => v.eq_str(value),
-                    (PropertyFilterOperator::NotEqual(value), Some(v)) => !v.eq_str(value),
-                    (PropertyFilterOperator::NotEqual(_), None) => true,
-                    (PropertyFilterOperator::GreaterThan(value), Some(v)) => {
-                        compare_numeric(v, value, |a, b| a > b)
-                    }
-                    (PropertyFilterOperator::LessThan(value), Some(v)) => {
-                        compare_numeric(v, value, |a, b| a < b)
-                    }
-                    (PropertyFilterOperator::GreaterThanOrEqual(value), Some(v)) => {
-                        compare_numeric(v, value, |a, b| a >= b)
-                    }
-                    (PropertyFilterOperator::LessThanOrEqual(value), Some(v)) => {
-                        compare_numeric(v, value, |a, b| a <= b)
-                    }
-                    (PropertyFilterOperator::OneOf(values), Some(v)) => {
-                        values.iter().any(|candidate| v.eq_str(candidate))
-                    }
-                    (PropertyFilterOperator::NotOneOf(values), Some(v)) => {
-                        !values.iter().any(|candidate| v.eq_str(candidate))
-                    }
-                    (PropertyFilterOperator::Exist, Some(_)) => true,
-                    (PropertyFilterOperator::NotExist, None) => true,
-
-                    _ => false,
-                }
-            })
-        })
-    }
-}
-
 fn compare_numeric(a: &galileo_mvt::MvtValue, b: &str, cmp: impl Fn(f64, f64) -> bool) -> bool {
     if let Some(a_num) = a.as_f64()
         && let Ok(b_num) = b.parse::<f64>()
@@ -113,7 +38,8 @@ fn compare_numeric(a: &galileo_mvt::MvtValue, b: &str, cmp: impl Fn(f64, f64) ->
 /// A rule that specifies what kind of features can be drawing with the given symbol.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StyleRule {
-    /// If set, a feature must belong to the set layer. If not set, layer is not checked.
+    /// If set, a feature must belong to the set layer. If not set, rule is applied to all layers, that don't have
+    /// a rule (e.g. this will be used as a default style).
     pub layer_name: Option<String>,
     /// If set, the rule will only be applied at resolutions lower than this value.
     pub max_resolution: Option<f64>,
@@ -125,6 +51,42 @@ pub struct StyleRule {
     /// Symbol to draw a feature with.
     #[serde(default)]
     pub symbol: VectorTileSymbol,
+}
+
+impl StyleRule {
+    /// Returns true, if the rule should be applied for the given feature.
+    pub fn applies(&self, feature: &MvtFeature) -> bool {
+        self.properties.iter().all(|filter| {
+            let value = feature.properties.get(&filter.property_name);
+            match (&filter.operator, value) {
+                (PropertyFilterOperator::Equal(value), Some(v)) => v.eq_str(value),
+                (PropertyFilterOperator::NotEqual(value), Some(v)) => !v.eq_str(value),
+                (PropertyFilterOperator::NotEqual(_), None) => true,
+                (PropertyFilterOperator::GreaterThan(value), Some(v)) => {
+                    compare_numeric(v, value, |a, b| a > b)
+                }
+                (PropertyFilterOperator::LessThan(value), Some(v)) => {
+                    compare_numeric(v, value, |a, b| a < b)
+                }
+                (PropertyFilterOperator::GreaterThanOrEqual(value), Some(v)) => {
+                    compare_numeric(v, value, |a, b| a >= b)
+                }
+                (PropertyFilterOperator::LessThanOrEqual(value), Some(v)) => {
+                    compare_numeric(v, value, |a, b| a <= b)
+                }
+                (PropertyFilterOperator::OneOf(values), Some(v)) => {
+                    values.iter().any(|candidate| v.eq_str(candidate))
+                }
+                (PropertyFilterOperator::NotOneOf(values), Some(v)) => {
+                    !values.iter().any(|candidate| v.eq_str(candidate))
+                }
+                (PropertyFilterOperator::Exist, Some(_)) => true,
+                (PropertyFilterOperator::NotExist, None) => true,
+
+                _ => false,
+            }
+        })
+    }
 }
 
 /// A filter that checks if a feature's property matches specific criteria.

--- a/galileo/src/layer/vector_tile_layer/tile_provider/vt_processor.rs
+++ b/galileo/src/layer/vector_tile_layer/tile_provider/vt_processor.rs
@@ -1,4 +1,5 @@
-use galileo_mvt::{MvtFeature, MvtGeometry, MvtPolygon, MvtTile};
+use either::Either;
+use galileo_mvt::{MvtFeature, MvtGeometry, MvtLayer, MvtPolygon, MvtTile};
 use galileo_types::cartesian::{CartesianPoint2d, Point3, Rect, Vector2};
 use galileo_types::impls::{ClosedContour, Polygon};
 use galileo_types::{Contour, MultiContour, MultiPolygon, Polygon as PolygonTrait};
@@ -26,6 +27,21 @@ pub struct VectorTileDecodeContext {
     pub tile_schema: TileSchema,
     /// Render bundle to add render primitives to.
     pub bundle: RenderBundle,
+}
+
+fn get_rule_layers<'a>(
+    rule: &StyleRule,
+    all_rules: &'a [StyleRule],
+    layers: &'a [MvtLayer],
+) -> impl Iterator<Item = &'a MvtLayer> {
+    match &rule.layer_name {
+        Some(layer_name) => Either::Left(layers.iter().find(|l| &l.name == layer_name).into_iter()),
+        None => Either::Right(layers.iter().filter(|l| {
+            !all_rules
+                .iter()
+                .any(|r| r.layer_name.as_ref() == Some(&l.name))
+        })),
+    }
 }
 
 impl VtProcessor {
@@ -57,69 +73,79 @@ impl VtProcessor {
         );
         bundle.world_set.clip_area(&bounds);
 
-        for layer in mvt_tile.layers.iter().rev() {
-            for feature in &layer.features {
-                let Some(rule) = style.get_style_rule(&layer.name, lod_resolution, feature) else {
-                    continue;
-                };
+        for rule in &style.rules {
+            if rule.max_resolution.is_some_and(|v| v < lod_resolution) {
+                continue;
+            }
 
-                match &feature.geometry {
-                    MvtGeometry::Point(points) => {
-                        let Some(paint) =
-                            Self::get_point_symbol(rule, lod_resolution, feature, tile_schema)
-                        else {
-                            continue;
-                        };
+            if rule.min_resolution.is_some_and(|v| v > lod_resolution) {
+                continue;
+            }
 
-                        for point in points {
-                            let position = Self::transform_point(point, tile_resolution);
-                            match &paint.shape {
-                                PointShape::Label { text, style } => {
-                                    if !text.is_empty() {
-                                        bundle.add_label(
-                                            &position,
-                                            text,
-                                            style,
-                                            Vector2::default(),
-                                            false,
-                                        );
+            for layer in get_rule_layers(rule, &style.rules, &mvt_tile.layers) {
+                for feature in &layer.features {
+                    if !rule.applies(feature) {
+                        continue;
+                    }
+
+                    match &feature.geometry {
+                        MvtGeometry::Point(points) => {
+                            let Some(paint) =
+                                Self::get_point_symbol(rule, lod_resolution, feature, tile_schema)
+                            else {
+                                continue;
+                            };
+
+                            for point in points {
+                                let position = Self::transform_point(point, tile_resolution);
+                                match &paint.shape {
+                                    PointShape::Label { text, style } => {
+                                        if !text.is_empty() {
+                                            bundle.add_label(
+                                                &position,
+                                                text,
+                                                style,
+                                                Vector2::default(),
+                                                false,
+                                            );
+                                        }
+                                    }
+                                    _ => {
+                                        bundle.add_point(&position, &paint, lod_resolution);
                                     }
                                 }
-                                _ => {
-                                    bundle.add_point(&position, &paint, lod_resolution);
+                            }
+                        }
+                        MvtGeometry::LineString(contours) => {
+                            if let Some(paint) =
+                                Self::get_line_symbol(rule, lod_resolution, feature, tile_schema)
+                            {
+                                for contour in contours.contours() {
+                                    bundle.add_line(
+                                        &galileo_types::impls::Contour::new(
+                                            contour
+                                                .iter_points()
+                                                .map(|p| Self::transform_point(&p, tile_resolution))
+                                                .collect(),
+                                            false,
+                                        ),
+                                        &paint,
+                                        lod_resolution,
+                                    );
                                 }
                             }
                         }
-                    }
-                    MvtGeometry::LineString(contours) => {
-                        if let Some(paint) =
-                            Self::get_line_symbol(rule, lod_resolution, feature, tile_schema)
-                        {
-                            for contour in contours.contours() {
-                                bundle.add_line(
-                                    &galileo_types::impls::Contour::new(
-                                        contour
-                                            .iter_points()
-                                            .map(|p| Self::transform_point(&p, tile_resolution))
-                                            .collect(),
-                                        false,
-                                    ),
-                                    &paint,
-                                    lod_resolution,
-                                );
-                            }
-                        }
-                    }
-                    MvtGeometry::Polygon(polygons) => {
-                        if let Some(paint) =
-                            Self::get_polygon_symbol(rule, lod_resolution, feature, tile_schema)
-                        {
-                            for polygon in polygons.polygons() {
-                                bundle.add_polygon(
-                                    &Self::transform_polygon(polygon, tile_resolution),
-                                    &paint,
-                                    lod_resolution,
-                                );
+                        MvtGeometry::Polygon(polygons) => {
+                            if let Some(paint) =
+                                Self::get_polygon_symbol(rule, lod_resolution, feature, tile_schema)
+                            {
+                                for polygon in polygons.polygons() {
+                                    bundle.add_polygon(
+                                        &Self::transform_polygon(polygon, tile_resolution),
+                                        &paint,
+                                        lod_resolution,
+                                    );
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
There was no way to set the order in which features (or layers) of vector tiles were drawn. The order was fixed by the contents of the MVT tile.

This commit changes the logic of how vector tiles are drawn:
1. The style rules are drawn sequentially. E.g. the first rule is drawn first, then the second etc.
2. The features that correspond to several rules will be rendered several times (before all features were drawn at most once).
3. The default rules (the ones without `layer_name` set) are applied to all layers, that don't have any other rules applied to them.