### PR TITLE
feat: Add fade_in_duration config to vt layer

### DIFF
--- a/galileo-maplibre/src/layer/vector_tile.rs
+++ b/galileo-maplibre/src/layer/vector_tile.rs
@@ -54,6 +54,7 @@ pub fn try_create(
     })
     .with_tile_schema(tile_schema)
     .with_style(style)
+    .with_fade_in_duration(Default::default())
     .build()
     .ok()
 }

--- a/galileo/src/layer/vector_tile_layer/builder.rs
+++ b/galileo/src/layer/vector_tile_layer/builder.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 
@@ -52,6 +53,7 @@ pub struct VectorTileLayerBuilder {
     cache: CacheType,
     offline_mode: bool,
     attribution: Option<Attribution>,
+    fade_in_duration: Option<Duration>,
 }
 
 enum ProviderType {
@@ -89,6 +91,7 @@ impl VectorTileLayerBuilder {
             cache: CacheType::None,
             offline_mode: false,
             attribution: None,
+            fade_in_duration: None,
         }
     }
 
@@ -117,6 +120,7 @@ impl VectorTileLayerBuilder {
             cache: CacheType::None,
             offline_mode: false,
             attribution: None,
+            fade_in_duration: None,
         }
     }
 
@@ -373,6 +377,31 @@ impl VectorTileLayerBuilder {
         self
     }
 
+    /// Sets the layer tiles' fade in duration.
+    ///
+    /// If set to 0, tiles will appear on the map as soon as loaded without fade in animation.
+    ///
+    /// Default value: 300ms.
+    ///
+    /// ```
+    /// use galileo::layer::vector_tile_layer::VectorTileLayerBuilder;
+    ///
+    /// let layer = VectorTileLayerBuilder::new_rest(
+    ///     |index| {
+    ///         format!(
+    ///             "https://vector_tiles.example.com/{}/{}/{}.png",
+    ///             index.z, index.x, index.y
+    ///         )
+    ///     })
+    ///     .with_fade_in_duration(std::time::Duration::from_millis(500))
+    ///     .build()?;
+    /// # Ok::<(), galileo::error::GalileoError>(())
+    /// ```
+    pub fn with_fade_in_duration(mut self, fade_in_duration: Duration) -> Self {
+        self.fade_in_duration = Some(fade_in_duration);
+        self
+    }
+
     /// Consumes the builder and constructs the vector tile layer.
     ///
     /// Will return an error if the layer is configured incorrectly or if the cache controller
@@ -386,6 +415,7 @@ impl VectorTileLayerBuilder {
             cache,
             offline_mode,
             attribution,
+            fade_in_duration,
         } = self;
 
         let tile_schema = tile_schema.unwrap_or_else(|| {
@@ -431,6 +461,10 @@ impl VectorTileLayerBuilder {
         let style = style.unwrap_or_else(Self::default_style);
 
         let mut layer = VectorTileLayer::new(provider, style, tile_schema, attribution);
+        if let Some(fade_in_duration) = fade_in_duration {
+            layer.set_fade_in_duration(fade_in_duration);
+        }
+
         if let Some(messenger) = messenger {
             layer.set_messenger(messenger.into());
         }

--- a/galileo/src/layer/vector_tile_layer/mod.rs
+++ b/galileo/src/layer/vector_tile_layer/mod.rs
@@ -161,8 +161,12 @@ impl VectorTileLayer {
         }
     }
 
-    fn fade_in_time(&self) -> Duration {
-        Duration::from_millis(300)
+    fn fade_in_duration(&self) -> Duration {
+        self.displayed_tiles.fade_in_duration()
+    }
+
+    fn set_fade_in_duration(&mut self, fade_in_duration: Duration) {
+        self.displayed_tiles.set_fade_in_duration(fade_in_duration);
     }
 
     /// Change style of the layer and redraw it.
@@ -274,7 +278,7 @@ impl VectorTileLayer {
                 let k = web_time::Instant::now()
                     .duration_since(prev.replaced_at)
                     .as_secs_f32()
-                    / self.fade_in_time().as_secs_f32();
+                    / self.fade_in_duration().as_secs_f32();
 
                 if k >= 1.0 {
                     *prev_background = None;


### PR DESCRIPTION
Add `with_fade_in_duration` method to the `VectorTileLayerBuilder` and apply settings to the created tile.

We don't expose this config modification methods since the API is not fixed yet.

Apply 0 fade in to MaplibreLayers, since they use transparent tiles a lot which look poorly with fade in.