### PR TITLE
feat: Support for line layers in MaplibreLayer

### DIFF
--- a/galileo-maplibre/src/layer/mod.rs
+++ b/galileo-maplibre/src/layer/mod.rs
@@ -15,6 +15,25 @@ pub mod vector_tile;
 
 pub(crate) const UNSUPPORTED: &str = "[maplibre:unsupported]";
 
+/// Logs a debug message when an unsupported `Option`al style property is set (i.e. `Some`).
+///
+/// Usage: `log_unsupported!(layer.paint.some_field);`
+///
+/// The field path is used as the property name in the message, so no extra string is needed.
+macro_rules! log_unsupported {
+    ($field:expr) => {
+        if $field.is_some() {
+            log::debug!(
+                "{} '{}' is not supported yet; ignored",
+                $crate::layer::UNSUPPORTED,
+                stringify!($field),
+            );
+        }
+    };
+}
+
+pub(crate) use log_unsupported;
+
 /// A Galileo [`Layer`] that renders a Maplibre style definition.
 ///
 /// Internally owns one or more Galileo layers derived from the style's sources and renders them

--- a/galileo-maplibre/src/layer/vector_tile.rs
+++ b/galileo-maplibre/src/layer/vector_tile.rs
@@ -9,14 +9,14 @@ use galileo::layer::vector_tile_layer::expressions::{
     StepValue, StyleValue,
 };
 use galileo::layer::vector_tile_layer::style::{
-    StyleRule, VectorTilePolygonSymbol, VectorTileStyle, VectorTileSymbol,
+    StyleRule, VectorTileLineSymbol, VectorTilePolygonSymbol, VectorTileStyle, VectorTileSymbol,
 };
 use galileo::tile_schema::{TileSchema, TileSchemaBuilder, VerticalDirection};
 use serde::Deserialize;
 
-use crate::layer::UNSUPPORTED;
+use crate::layer::{UNSUPPORTED, log_unsupported};
 use crate::style::color::MlColor;
-use crate::style::layer::{FillLayer, Layer as MaplibreStyleLayer};
+use crate::style::layer::{FillLayer, Layer as MaplibreStyleLayer, LineLayer};
 use crate::style::source::{TileScheme, VectorSource};
 use crate::style::value::{FunctionStop, MlStyleValue};
 
@@ -91,22 +91,19 @@ fn get_background(layers: &[&MaplibreStyleLayer]) -> StyleValue<Color> {
         }
     };
 
-    let Some(color) = &layer.paint.background_color else {
-        return DEFAULT_TILE_BACKGROUND;
-    };
-
-    get_color_value(color, layer.paint.background_opacity.as_ref())
-        .unwrap_or(DEFAULT_TILE_BACKGROUND)
+    get_color_value(
+        &layer.paint.background_color,
+        &layer.paint.background_opacity,
+    )
+    .unwrap_or(DEFAULT_TILE_BACKGROUND)
 }
 
 fn get_color_value(
     color: &MlStyleValue<MlColor>,
-    opacity: Option<&MlStyleValue<f64>>,
+    opacity: &MlStyleValue<f64>,
 ) -> Option<StyleValue<Color>> {
     let galileo_color = get_galileo_value(color)?;
-    let galileo_opacity = opacity
-        .and_then(get_galileo_value)
-        .unwrap_or(StyleValue::Simple(1.0));
+    let galileo_opacity = get_galileo_value(opacity).unwrap_or(StyleValue::Simple(1.0));
 
     match (galileo_color, galileo_opacity) {
         (StyleValue::Simple(c), StyleValue::Simple(o)) => Some((*c).with_alpha_float(o).into()),
@@ -193,11 +190,11 @@ fn build_rules(layers: &[&MaplibreStyleLayer], tile_schema: &TileSchema) -> Vec<
             MaplibreStyleLayer::Fill(fill) => {
                 if let Some(rule) = fill_rule(fill, tile_schema) {
                     rules.push(rule);
-                    log::debug!(
-                        "Maplibre layer '{}' of type '{}' is added as a VT style rule",
-                        layer.id(),
-                        layer.type_name()
-                    );
+                }
+            }
+            MaplibreStyleLayer::Line(line) => {
+                if let Some(rule) = line_rule(line, tile_schema) {
+                    rules.push(rule);
                 }
             }
             other => {
@@ -207,8 +204,16 @@ fn build_rules(layers: &[&MaplibreStyleLayer], tile_schema: &TileSchema) -> Vec<
                     other.type_name(),
                     other.id(),
                 );
+
+                continue;
             }
         }
+
+        log::trace!(
+            "Maplibre layer '{}' of type '{}' is added as a VT style rule",
+            layer.id(),
+            layer.type_name()
+        );
     }
     rules
 }
@@ -226,9 +231,16 @@ fn fill_rule(fill: &FillLayer, tile_schema: &TileSchema) -> Option<StyleRule> {
         }
     };
 
-    let fill_color = fill.paint.fill_color.as_ref()?;
+    let fill_color = &fill.paint.fill_color;
     let fill_opacity = &fill.paint.fill_opacity;
-    let color = get_color_value(fill_color, fill_opacity.as_ref())?;
+    let color = get_color_value(fill_color, fill_opacity)?;
+
+    log_unsupported!(fill.paint.fill_antialias);
+    log_unsupported!(fill.paint.fill_outline_color);
+    log_unsupported!(fill.paint.fill_pattern);
+    log_unsupported!(fill.paint.fill_translate);
+    log_unsupported!(fill.paint.fill_translate_anchor);
+    log_unsupported!(fill.paint.fill_emissive_strength);
 
     let min_resolution = fill
         .maxzoom
@@ -240,6 +252,61 @@ fn fill_rule(fill: &FillLayer, tile_schema: &TileSchema) -> Option<StyleRule> {
     Some(StyleRule {
         layer_name: Some(source_layer),
         symbol: VectorTileSymbol::Polygon(VectorTilePolygonSymbol { fill_color: color }),
+        min_resolution,
+        max_resolution,
+        ..Default::default()
+    })
+}
+
+/// Converts a [`LineLayer`] to a [`StyleRule`], or logs and returns `None` if unsupported.
+fn line_rule(line: &LineLayer, tile_schema: &TileSchema) -> Option<StyleRule> {
+    if line.paint.line_dasharray.is_some() {
+        log::debug!(
+            "{UNSUPPORTED} Line dasharray is not supported yet; skipping layer {}",
+            line.id
+        );
+        return None;
+    }
+
+    log_unsupported!(line.paint.line_blur);
+    log_unsupported!(line.paint.line_gap_width);
+    log_unsupported!(line.paint.line_gradient);
+    log_unsupported!(line.paint.line_pattern);
+    log_unsupported!(line.paint.line_translate);
+    log_unsupported!(line.paint.line_translate_anchor);
+    log_unsupported!(line.paint.line_emissive_strength);
+    log_unsupported!(line.paint.line_offset);
+
+    let source_layer = match &line.source_layer {
+        Some(l) => l.clone(),
+        None => {
+            log::debug!(
+                "{UNSUPPORTED} Line layer '{}' has no source-layer; skipping.",
+                line.id
+            );
+            return None;
+        }
+    };
+
+    let stroke_color = &line.paint.line_color;
+    let stroke_opacity = &line.paint.line_opacity;
+    let color = get_color_value(stroke_color, stroke_opacity).unwrap_or(Color::TRANSPARENT.into());
+    let stroke_width = &line.paint.line_width;
+    let width = get_galileo_value(stroke_width).unwrap_or(1.0.into());
+
+    let min_resolution = line
+        .maxzoom
+        .and_then(|lod| tile_schema.lod_resolution(lod.round() as u32));
+    let max_resolution = line
+        .minzoom
+        .and_then(|lod| tile_schema.lod_resolution(lod.round() as u32));
+
+    Some(StyleRule {
+        layer_name: Some(source_layer),
+        symbol: VectorTileSymbol::Line(VectorTileLineSymbol {
+            width,
+            stroke_color: color,
+        }),
         min_resolution,
         max_resolution,
         ..Default::default()

--- a/galileo-maplibre/src/style/color.rs
+++ b/galileo-maplibre/src/style/color.rs
@@ -6,7 +6,7 @@ use galileo::Color;
 use serde::{Deserialize, Deserializer};
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
-pub struct MlColor(Color);
+pub struct MlColor(pub(crate) Color);
 
 impl<'de> Deserialize<'de> for MlColor {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {

--- a/galileo-maplibre/src/style/layer/background.rs
+++ b/galileo-maplibre/src/style/layer/background.rs
@@ -5,24 +5,48 @@ use serde_json::Value;
 
 use super::common::CommonLayout;
 use crate::style::color::MlColor;
-use crate::style::deserialize_opt_f64;
 use crate::style::value::MlStyleValue;
+use crate::style::{
+    default_one, default_transparent, deser_default_one, deser_default_transparent,
+    deserialize_opt_f64,
+};
 
 /// Paint properties for a background layer.
-#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct BackgroundPaint {
     /// The colour with which the background will be drawn.
-    #[serde(rename = "background-color")]
-    pub background_color: Option<MlStyleValue<MlColor>>,
+    #[serde(
+        rename = "background-color",
+        default = "default_transparent",
+        deserialize_with = "deser_default_transparent"
+    )]
+    pub background_color: MlStyleValue<MlColor>,
+
     /// The opacity at which the background will be drawn.
-    #[serde(rename = "background-opacity")]
-    pub background_opacity: Option<MlStyleValue<f64>>,
+    #[serde(
+        rename = "background-opacity",
+        default = "default_one",
+        deserialize_with = "deser_default_one"
+    )]
+    pub background_opacity: MlStyleValue<f64>,
+
     /// Name of image in sprite to use for drawing an image background.
     #[serde(rename = "background-pattern")]
     pub background_pattern: Option<Value>,
     /// Controls the intensity of light emitted on the source features.
     #[serde(rename = "background-emissive-strength")]
     pub background_emissive_strength: Option<Value>,
+}
+
+impl Default for BackgroundPaint {
+    fn default() -> Self {
+        Self {
+            background_color: default_transparent(),
+            background_opacity: default_one(),
+            background_pattern: Default::default(),
+            background_emissive_strength: Default::default(),
+        }
+    }
 }
 
 /// Layout properties for a background layer (visibility only).

--- a/galileo-maplibre/src/style/layer/fill.rs
+++ b/galileo-maplibre/src/style/layer/fill.rs
@@ -5,11 +5,14 @@ use serde_json::Value;
 
 use super::common::CommonLayout;
 use crate::style::color::MlColor;
-use crate::style::deserialize_opt_f64;
 use crate::style::value::MlStyleValue;
+use crate::style::{
+    default_one, default_transparent, deser_default_one, deser_default_transparent,
+    deserialize_opt_f64,
+};
 
 /// Paint properties for a `fill` layer.
-#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct FillPaint {
     /// Whether or not the fill should be antialiased. Supports expressions.
     #[serde(rename = "fill-antialias", skip_serializing_if = "Option::is_none")]
@@ -18,22 +21,24 @@ pub struct FillPaint {
     /// Fill colour.
     #[serde(
         rename = "fill-color",
-        default,
+        default = "default_transparent",
+        deserialize_with = "deser_default_transparent",
         skip_serializing_if = "Option::is_none"
     )]
-    pub fill_color: Option<MlStyleValue<MlColor>>,
+    pub fill_color: MlStyleValue<MlColor>,
 
     /// Outline colour.
-    #[serde(
-        rename = "fill-outline-color",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub fill_outline_color: Option<MlStyleValue<MlColor>>,
+    #[serde(rename = "fill-outline-color", skip_serializing_if = "Option::is_none")]
+    pub fill_outline_color: Option<Value>,
 
     /// Opacity of the entire fill layer. Supports expressions.
-    #[serde(rename = "fill-opacity", skip_serializing_if = "Option::is_none")]
-    pub fill_opacity: Option<MlStyleValue<f64>>,
+    #[serde(
+        rename = "fill-opacity",
+        default = "default_one",
+        deserialize_with = "deser_default_one",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub fill_opacity: MlStyleValue<f64>,
 
     /// Name of image in sprite to use for drawing the fill pattern.
     #[serde(rename = "fill-pattern", skip_serializing_if = "Option::is_none")]
@@ -56,6 +61,21 @@ pub struct FillPaint {
         skip_serializing_if = "Option::is_none"
     )]
     pub fill_emissive_strength: Option<Value>,
+}
+
+impl Default for FillPaint {
+    fn default() -> Self {
+        Self {
+            fill_antialias: Default::default(),
+            fill_color: default_transparent(),
+            fill_outline_color: Default::default(),
+            fill_opacity: default_one(),
+            fill_pattern: Default::default(),
+            fill_translate: Default::default(),
+            fill_translate_anchor: Default::default(),
+            fill_emissive_strength: Default::default(),
+        }
+    }
 }
 
 /// Layout properties for a `fill` layer (visibility only).

--- a/galileo-maplibre/src/style/layer/line.rs
+++ b/galileo-maplibre/src/style/layer/line.rs
@@ -4,22 +4,42 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use super::common::{Visibility, deserialize_visibility_or_default};
-use crate::style::deserialize_opt_f64;
+use crate::style::color::MlColor;
+use crate::style::value::MlStyleValue;
+use crate::style::{
+    default_one, default_transparent, deser_default_one, deser_default_transparent,
+    deserialize_opt_f64,
+};
 
 /// Paint properties for a `line` layer.
-#[derive(Debug, Clone, PartialEq, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct LinePaint {
     /// Line stroke colour. Supports expressions.
-    #[serde(rename = "line-color", skip_serializing_if = "Option::is_none")]
-    pub line_color: Option<Value>,
+    #[serde(
+        rename = "line-color",
+        default = "default_transparent",
+        deserialize_with = "deser_default_transparent",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub line_color: MlStyleValue<MlColor>,
 
     /// Line stroke opacity. Supports expressions.
-    #[serde(rename = "line-opacity", skip_serializing_if = "Option::is_none")]
-    pub line_opacity: Option<Value>,
+    #[serde(
+        rename = "line-opacity",
+        default = "default_one",
+        deserialize_with = "deser_default_one",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub line_opacity: MlStyleValue<f64>,
 
     /// Line stroke width in pixels. Supports expressions.
-    #[serde(rename = "line-width", skip_serializing_if = "Option::is_none")]
-    pub line_width: Option<Value>,
+    #[serde(
+        rename = "line-width",
+        default = "default_one",
+        deserialize_with = "deser_default_one",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub line_width: MlStyleValue<f64>,
 
     /// Line blur. Supports expressions.
     #[serde(rename = "line-blur", skip_serializing_if = "Option::is_none")]
@@ -62,6 +82,25 @@ pub struct LinePaint {
     /// Stroke offset relative to the line's direction. Supports expressions.
     #[serde(rename = "line-offset", skip_serializing_if = "Option::is_none")]
     pub line_offset: Option<Value>,
+}
+
+impl Default for LinePaint {
+    fn default() -> Self {
+        Self {
+            line_color: default_transparent(),
+            line_opacity: default_one(),
+            line_width: default_one(),
+            line_blur: Default::default(),
+            line_dasharray: Default::default(),
+            line_gap_width: Default::default(),
+            line_gradient: Default::default(),
+            line_pattern: Default::default(),
+            line_translate: Default::default(),
+            line_translate_anchor: Default::default(),
+            line_emissive_strength: Default::default(),
+            line_offset: Default::default(),
+        }
+    }
 }
 
 /// Layout properties for a `line` layer.

--- a/galileo-maplibre/src/style/layer/mod.rs
+++ b/galileo-maplibre/src/style/layer/mod.rs
@@ -126,7 +126,11 @@ impl Layer {
 
 #[cfg(test)]
 mod tests {
+    use galileo::Color;
+
     use super::*;
+    use crate::style::color::MlColor;
+    use crate::style::value::MlStyleValue;
 
     #[test]
     fn parse_background_layer() {
@@ -396,6 +400,9 @@ mod tests {
             panic!("expected Background")
         };
         assert_eq!(bg.layout.visibility, Visibility::Visible);
-        assert!(bg.paint.background_color.is_none());
+        assert_eq!(
+            bg.paint.background_color,
+            MlStyleValue::Literal(MlColor(Color::TRANSPARENT))
+        );
     }
 }

--- a/galileo-maplibre/src/style/mod.rs
+++ b/galileo-maplibre/src/style/mod.rs
@@ -15,12 +15,18 @@ pub mod layer;
 pub mod source;
 pub mod value;
 
+use std::any::type_name;
 use std::collections::HashMap;
 
+use galileo::Color;
 use layer::Layer;
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 use source::Source;
+
+use crate::style::color::MlColor;
+use crate::style::value::MlStyleValue;
 
 /// A single sprite definition referencing an external sprite sheet.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -237,6 +243,48 @@ where
         }
     }
     Ok(out)
+}
+
+fn deser_or_default<'de, D, T>(deserializer: D, default: T) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: DeserializeOwned,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Null => Ok(default),
+        v => serde_json::from_value::<T>(v.clone()).or_else(|err| {
+            log::warn!(
+                "Invalid {} value {v}: {err}; using default",
+                type_name::<T>()
+            );
+            Ok(default)
+        }),
+    }
+}
+
+fn default_one() -> MlStyleValue<f64> {
+    MlStyleValue::Literal(1.0)
+}
+
+fn deser_default_one<'de, D>(deserializer: D) -> Result<MlStyleValue<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deser_or_default(deserializer, MlStyleValue::Literal(1.0))
+}
+
+fn default_transparent() -> MlStyleValue<MlColor> {
+    MlStyleValue::Literal(MlColor(Color::TRANSPARENT))
+}
+
+fn deser_default_transparent<'de, D>(deserializer: D) -> Result<MlStyleValue<MlColor>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deser_or_default(
+        deserializer,
+        MlStyleValue::Literal(MlColor(Color::TRANSPARENT)),
+    )
 }
 
 /// Deserialises a required `f64` field, falling back to `Default` and logging


### PR DESCRIPTION
Convert maplibre line layers to Galileo vt style rules. At this point only stroke color and width properties are supported.

Also, refactored a little how values are parsed.