### PR TITLE
refactor: Rename ExprDeser to TypedExpr and make them typed

### DIFF
--- a/galileo-maplibre/src/layer/vector_tile.rs
+++ b/galileo-maplibre/src/layer/vector_tile.rs
@@ -1,6 +1,6 @@
 use galileo::Color;
 use galileo::expr::{
-    ControlPoint, ExponentialInterpolation, Expr, ExprDeser, ExprValue, WithOpacityExpr,
+    ColorExpr, ControlPoint, ExponentialInterpolation, Expr, ExprValue, WithOpacityExpr,
 };
 use galileo::galileo_types::cartesian::{CartesianPoint2d, Point2, Rect};
 use galileo::galileo_types::geo::impls::GeoPoint2d;
@@ -62,9 +62,9 @@ pub fn try_create(
 ///
 /// Maptiler supports having background layer in any position, and just adds filling of the
 /// entire tile. WE don't support this currently, and always put background at the back.
-fn get_background(layers: &[&MaplibreStyleLayer]) -> ExprDeser {
-    const DEFAULT_TILE_BACKGROUND: ExprDeser =
-        ExprDeser(Expr::Literal(ExprValue::Color(Color::TRANSPARENT)));
+fn get_background(layers: &[&MaplibreStyleLayer]) -> ColorExpr {
+    const DEFAULT_TILE_BACKGROUND: ColorExpr =
+        ColorExpr::new(Expr::Literal(ExprValue::Color(Color::TRANSPARENT)));
 
     let layer = match layers {
         [] => return DEFAULT_TILE_BACKGROUND,

--- a/galileo/src/expr/mod.rs
+++ b/galileo/src/expr/mod.rs
@@ -1,5 +1,7 @@
 #![allow(missing_docs)] //TODO: temporary allow
 
+use std::marker::PhantomData;
+
 use serde::{Deserialize, Deserializer, Serialize};
 
 mod interpolation;
@@ -46,35 +48,57 @@ pub enum Expr {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(transparent)]
-pub struct ExprDeser(pub Expr);
+pub struct TypedExpr<Out>(Expr, PhantomData<Out>);
 
-impl Default for ExprDeser {
+pub type ColorExpr = TypedExpr<Color>;
+pub type NumExpr = TypedExpr<f64>;
+pub type BoolExpr = TypedExpr<bool>;
+
+impl<T> Default for TypedExpr<T> {
     fn default() -> Self {
-        Self(Expr::Literal(ExprValue::Null))
+        Self(Expr::Literal(ExprValue::Null), PhantomData)
     }
 }
 
-impl ExprDeser {
-    pub fn eval<'a>(&'a self, f: &'a impl ExprFeature, v: ExprView) -> ExprValue<&'a str> {
-        self.0.eval(f, v)
+impl<Out> TypedExpr<Out> {
+    pub const fn new(expr: Expr) -> Self {
+        Self(expr, PhantomData)
     }
 }
 
-impl From<Expr> for ExprDeser {
+impl TypedExpr<Color> {
+    pub fn eval(&self, f: &impl ExprFeature, v: ExprView) -> Option<Color> {
+        self.0.eval(f, v).as_color()
+    }
+}
+
+impl TypedExpr<f64> {
+    pub fn eval(&self, f: &impl ExprFeature, v: ExprView) -> Option<f64> {
+        self.0.eval(f, v).as_number()
+    }
+}
+
+impl TypedExpr<bool> {
+    pub fn eval(&self, f: &impl ExprFeature, v: ExprView) -> bool {
+        self.0.eval(f, v).to_bool()
+    }
+}
+
+impl<Out> From<Expr> for TypedExpr<Out> {
     fn from(value: Expr) -> Self {
-        Self(value)
+        Self::new(value)
     }
 }
 
-impl From<Color> for ExprDeser {
+impl From<Color> for TypedExpr<Color> {
     fn from(value: Color) -> Self {
-        Self(Expr::Literal(value.into()))
+        Expr::Literal(value.into()).into()
     }
 }
 
-impl From<f64> for ExprDeser {
+impl From<f64> for TypedExpr<f64> {
     fn from(value: f64) -> Self {
-        Self(Expr::Literal(value.into()))
+        Expr::Literal(value.into()).into()
     }
 }
 
@@ -90,7 +114,7 @@ impl From<f64> for Expr {
     }
 }
 
-impl<'de> Deserialize<'de> for ExprDeser {
+impl<'de, Out> Deserialize<'de> for TypedExpr<Out> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         // Buffer into a generic value so we can inspect the shape without consuming the input.
         let value = serde_json::Value::deserialize(deserializer)?;
@@ -197,7 +221,7 @@ mod tests {
     #[test]
     fn deserialize_expr_from_string() {
         let json = r#""kind == \"road\"""#;
-        let expr: ExprDeser = serde_json::from_str(json).unwrap();
+        let expr: BoolExpr = serde_json::from_str(json).unwrap();
         assert_eq!(
             expr.0,
             Expr::Eq(
@@ -210,13 +234,13 @@ mod tests {
     #[test]
     fn deserialize_expr_from_object() {
         let json = r#"{"Get": "kind"}"#;
-        let expr: ExprDeser = serde_json::from_str(json).unwrap();
+        let expr: NumExpr = serde_json::from_str(json).unwrap();
         assert_eq!(expr.0, Expr::Get("kind".to_string()));
     }
 
     #[test]
     fn deserialize_bad_string_returns_error() {
         let json = r#""@@@ not valid @@@""#;
-        assert!(serde_json::from_str::<Expr>(json).is_err());
+        assert!(serde_json::from_str::<NumExpr>(json).is_err());
     }
 }

--- a/galileo/src/layer/vector_tile_layer/mod.rs
+++ b/galileo/src/layer/vector_tile_layer/mod.rs
@@ -14,7 +14,7 @@ use galileo_types::impls::{ClosedContour, Polygon};
 use parking_lot::Mutex;
 pub use vector_tile::VectorTile;
 
-use crate::expr::{EmptyExprFeature, ExprDeser, ExprView};
+use crate::expr::{ColorExpr, EmptyExprFeature, ExprView};
 use crate::layer::Layer;
 use crate::layer::attribution::Attribution;
 use crate::layer::vector_tile_layer::style::VectorTileStyle;
@@ -55,7 +55,7 @@ impl std::fmt::Debug for VectorTileLayer {
 
 #[derive(Debug, Clone)]
 struct PreviousBackground {
-    color: ExprDeser,
+    color: ColorExpr,
     replaced_at: web_time::Instant,
 }
 
@@ -274,10 +274,7 @@ impl VectorTileLayer {
         };
 
         let mut prev_background = self.prev_background.lock();
-        let new_color = style
-            .background
-            .eval(&EmptyExprFeature, expr_view)
-            .as_color()?;
+        let new_color = style.background.eval(&EmptyExprFeature, expr_view)?;
         let color = match &*prev_background {
             Some(prev) => {
                 let k = web_time::Instant::now()
@@ -289,7 +286,7 @@ impl VectorTileLayer {
                     *prev_background = None;
                     new_color
                 } else {
-                    let prev_color = prev.color.eval(&EmptyExprFeature, expr_view).as_color()?;
+                    let prev_color = prev.color.eval(&EmptyExprFeature, expr_view)?;
                     prev_color.blend(new_color.with_alpha((new_color.a() as f32 * k) as u8))
                 }
             }

--- a/galileo/src/layer/vector_tile_layer/style.rs
+++ b/galileo/src/layer/vector_tile_layer/style.rs
@@ -4,7 +4,9 @@ use galileo_mvt::{MvtFeature, MvtValue};
 use serde::{Deserialize, Serialize};
 
 use crate::Color;
-use crate::expr::{ExprDeser, ExprFeature, ExprGeometryType, ExprValue, ExprView};
+use crate::expr::{
+    BoolExpr, ColorExpr, ExprFeature, ExprGeometryType, ExprValue, ExprView, NumExpr,
+};
 use crate::render::point_paint::PointPaint;
 use crate::render::text::{
     FontStyle, FontWeight, HorizontalAlignment, TextStyle, VerticalAlignment,
@@ -21,7 +23,7 @@ pub struct VectorTileStyle {
     pub rules: Vec<StyleRule>,
 
     /// Background color of tiles.
-    pub background: ExprDeser,
+    pub background: ColorExpr,
 }
 
 /// A rule that specifies what kind of features can be drawing with the given symbol.
@@ -36,7 +38,7 @@ pub struct StyleRule {
     pub min_resolution: Option<f64>,
     /// Specifies a set of attributes of a feature that must have the given values for this rule to be applied.
     #[serde(default)]
-    pub filter: Option<ExprDeser>,
+    pub filter: Option<BoolExpr>,
     /// Symbol to draw a feature with.
     #[serde(default)]
     pub symbol: VectorTileSymbol,
@@ -54,7 +56,7 @@ impl StyleRule {
             z_index: Some(z_index),
         };
 
-        expr.eval(feature, expr_view).as_bool().unwrap_or(false)
+        expr.eval(feature, expr_view)
     }
 }
 
@@ -149,16 +151,16 @@ impl VectorTileSymbol {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VectorTilePointSymbol {
     /// Size of the point.
-    pub size: ExprDeser,
+    pub size: NumExpr,
     /// Color of the point.
-    pub color: ExprDeser,
+    pub color: ColorExpr,
 }
 
 impl VectorTilePointSymbol {
     pub(crate) fn to_paint(&self, feature: &MvtFeature, view: ExprView) -> Option<PointPaint<'_>> {
         Some(PointPaint::circle(
-            self.color.eval(feature, view).as_color()?,
-            self.size.eval(feature, view).as_number()? as f32,
+            self.color.eval(feature, view)?,
+            self.size.eval(feature, view)? as f32,
         ))
     }
 }
@@ -167,16 +169,16 @@ impl VectorTilePointSymbol {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VectorTileLineSymbol {
     /// Width of the line in pixels.
-    pub width: ExprDeser,
+    pub width: NumExpr,
     /// Color of the line in pixels.
-    pub stroke_color: ExprDeser,
+    pub stroke_color: ColorExpr,
 }
 
 impl VectorTileLineSymbol {
     pub(crate) fn to_paint(&self, feature: &MvtFeature, view: ExprView) -> Option<LinePaint> {
         Some(LinePaint {
-            color: self.stroke_color.eval(feature, view).as_color()?,
-            width: self.width.eval(feature, view).as_number()?,
+            color: self.stroke_color.eval(feature, view)?,
+            width: self.width.eval(feature, view)?,
             offset: 0.0,
             line_cap: LineCap::Butt,
         })
@@ -187,13 +189,13 @@ impl VectorTileLineSymbol {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct VectorTilePolygonSymbol {
     /// Color of the fill of polygon.
-    pub fill_color: ExprDeser,
+    pub fill_color: ColorExpr,
 }
 
 impl VectorTilePolygonSymbol {
     pub(crate) fn to_paint(&self, feature: &MvtFeature, view: ExprView) -> Option<PolygonPaint> {
         Some(PolygonPaint {
-            color: self.fill_color.eval(feature, view).as_color()?,
+            color: self.fill_color.eval(feature, view)?,
         })
     }
 }
@@ -214,10 +216,10 @@ pub struct VtTextStyle {
     /// Name of the font to use.
     pub font_family: Vec<String>,
     /// Size of the font in pixels.
-    pub font_size: ExprDeser,
+    pub font_size: NumExpr,
     /// Color of the font.
     #[serde(default = "default_font_color_style")]
-    pub font_color: ExprDeser,
+    pub font_color: ColorExpr,
     /// Alignment of label along horizontal axis.
     #[serde(default)]
     pub horizontal_alignment: HorizontalAlignment,
@@ -232,10 +234,10 @@ pub struct VtTextStyle {
     pub style: FontStyle,
     /// Width of the outline around the letters.
     #[serde(default = "default_outline_width_style")]
-    pub outline_width: ExprDeser,
+    pub outline_width: NumExpr,
     /// Color of the outline around the letters.
     #[serde(default = "default_outline_color_style")]
-    pub outline_color: ExprDeser,
+    pub outline_color: ColorExpr,
 }
 
 impl VtTextStyle {
@@ -244,27 +246,27 @@ impl VtTextStyle {
     pub fn get_value(self, feature: &MvtFeature, view: ExprView) -> Option<TextStyle> {
         Some(TextStyle {
             font_family: self.font_family,
-            font_size: self.font_size.eval(feature, view).as_number()? as f32,
-            font_color: self.font_color.eval(feature, view).as_color()?,
+            font_size: self.font_size.eval(feature, view)? as f32,
+            font_color: self.font_color.eval(feature, view)?,
             horizontal_alignment: self.horizontal_alignment,
             vertical_alignment: self.vertical_alignment,
             weight: self.weight,
             style: self.style,
-            outline_width: self.outline_width.eval(feature, view).as_number()? as f32,
-            outline_color: self.outline_color.eval(feature, view).as_color()?,
+            outline_width: self.outline_width.eval(feature, view)? as f32,
+            outline_color: self.outline_color.eval(feature, view)?,
         })
     }
 }
 
-fn default_font_color_style() -> ExprDeser {
+fn default_font_color_style() -> ColorExpr {
     Color::BLACK.into()
 }
 
-fn default_outline_color_style() -> ExprDeser {
+fn default_outline_color_style() -> ColorExpr {
     Color::TRANSPARENT.into()
 }
 
-fn default_outline_width_style() -> ExprDeser {
+fn default_outline_width_style() -> NumExpr {
     0.0.into()
 }
 


### PR DESCRIPTION
Make top-level expressions used by the consumers typed, making them evaluate to a specific type instead of generic value. Also add type aliases for the type expressions we use:
* `ColorExpr`
* `NumExpr`
* `BoolExpr`