### PR TITLE
fix: Use rgba texture color space instead of srgb

### DIFF
--- a/galileo/examples/labels.rs
+++ b/galileo/examples/labels.rs
@@ -32,7 +32,7 @@ struct EguiMapApp {
     is_bold: bool,
     is_italic: bool,
     outline_width: f32,
-    outline_color: Color32,
+    outline_color: [f32; 4],
     attach_to_map: bool,
 }
 
@@ -52,7 +52,7 @@ impl EguiMapApp {
             is_bold: false,
             is_italic: false,
             outline_width: 0.0,
-            outline_color: Color32::WHITE,
+            outline_color: Color32::WHITE.to_normalized_gamma_f32(),
             attach_to_map: false,
         }
     }
@@ -78,10 +78,10 @@ impl EguiMapApp {
                 style,
                 outline_width: self.outline_width,
                 outline_color: Color::rgba(
-                    self.outline_color.r(),
-                    self.outline_color.g(),
-                    self.outline_color.b(),
-                    self.outline_color.a(),
+                    (self.outline_color[0] * 255.0) as u8,
+                    (self.outline_color[1] * 255.0) as u8,
+                    (self.outline_color[2] * 255.0) as u8,
+                    (self.outline_color[3] * 255.0) as u8,
                 ),
             },
             attach_to_map: self.attach_to_map,
@@ -207,7 +207,7 @@ impl eframe::App for EguiMapApp {
                     }
 
                     if ui
-                        .color_edit_button_srgba(&mut self.outline_color)
+                        .color_edit_button_rgba_unmultiplied(&mut self.outline_color)
                         .changed()
                     {
                         self.update_symbol();

--- a/galileo/src/render/wgpu/pipelines/mod.rs
+++ b/galileo/src/render/wgpu/pipelines/mod.rs
@@ -214,7 +214,7 @@ impl Pipelines {
                     mip_level_count: 1,
                     sample_count: 1,
                     dimension: wgpu::TextureDimension::D2,
-                    format: TextureFormat::Rgba8UnormSrgb,
+                    format: TextureFormat::Rgba8Unorm,
                     usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
                     label: None,
                     view_formats: &[],
@@ -231,7 +231,7 @@ impl Pipelines {
                     mip_level_count: 1,
                     sample_count: 1,
                     dimension: wgpu::TextureDimension::D2,
-                    format: TextureFormat::Rgba8UnormSrgb,
+                    format: TextureFormat::Rgba8Unorm,
                     usage: wgpu::TextureUsages::TEXTURE_BINDING
                         | wgpu::TextureUsages::COPY_DST
                         | wgpu::TextureUsages::RENDER_ATTACHMENT,
@@ -252,7 +252,7 @@ impl Pipelines {
                     &image,
                     texture
                         .as_image_copy()
-                        .to_tagged(wgpu::PredefinedColorSpace::Srgb, false),
+                        .to_tagged(wgpu::PredefinedColorSpace::DisplayP3, false),
                     texture_size,
                 );
 


### PR DESCRIPTION
We decode images to standard rgba, so making wgpu assume srgb colors renders incorrect result.

This fixes issue rased in #323 