### PR TITLE
Allow dasharrays to be exressions

### DIFF
--- a/galileo-maplibre/src/layer/vector_tile.rs
+++ b/galileo-maplibre/src/layer/vector_tile.rs
@@ -64,7 +64,7 @@ pub fn try_create(
 /// entire tile. WE don't support this currently, and always put background at the back.
 fn get_background(layers: &[&MaplibreStyleLayer]) -> ColorExpr {
     const DEFAULT_TILE_BACKGROUND: ColorExpr =
-        ColorExpr::new(Expr::Literal(ExprValue::Color(Color::TRANSPARENT)));
+        ColorExpr::new(Expr::Value(ExprValue::Color(Color::TRANSPARENT)));
 
     let layer = match layers {
         [] => return DEFAULT_TILE_BACKGROUND,
@@ -113,13 +113,13 @@ fn get_color_value(color: &MlStyleValue<MlColor>, opacity: &MlStyleValue<f64>) -
     })
 }
 
-fn get_galileo_value<T: Copy + Default + std::fmt::Debug>(value: &MlStyleValue<T>) -> Option<Expr>
+fn get_galileo_value<T: Clone + Default + std::fmt::Debug>(value: &MlStyleValue<T>) -> Option<Expr>
 where
     for<'de> FunctionStop<T>: Deserialize<'de>,
-    ExprValue<String>: From<T>,
+    ExprValue<'static>: From<T>,
 {
     match value {
-        MlStyleValue::Literal(v) => Some(Expr::Literal(ExprValue::from(*v))),
+        MlStyleValue::Literal(v) => Some(Expr::Value(ExprValue::from(v.clone()))),
         MlStyleValue::Expression(expr) => expr.to_galileo_expr(),
         MlStyleValue::Function(function) => {
             let control_points = function
@@ -127,7 +127,7 @@ where
                 .iter()
                 .map(|stop| ControlPoint {
                     input: stop.input.into(),
-                    output: ExprValue::<String>::from(stop.output).into(),
+                    output: ExprValue::from(stop.output.clone()).into(),
                 })
                 .collect();
 
@@ -298,7 +298,11 @@ fn line_rule(line: &LineLayer, tile_schema: &TileSchema) -> Option<StyleRule> {
         .minzoom
         .and_then(|lod| tile_schema.lod_resolution(lod.round() as u32));
     let filter = line.filter.as_ref().and_then(|v| v.to_galileo_expr());
-    let dasharray = line.paint.line_dasharray.clone();
+    let dasharray = line
+        .paint
+        .line_dasharray
+        .as_ref()
+        .and_then(|v| get_galileo_value(v).map(|v| v.into()));
 
     Some(StyleRule {
         layer_name: Some(source_layer),

--- a/galileo-maplibre/src/style/color.rs
+++ b/galileo-maplibre/src/style/color.rs
@@ -24,7 +24,7 @@ impl From<MlColor> for Color {
     }
 }
 
-impl<T> From<MlColor> for ExprValue<T> {
+impl From<MlColor> for ExprValue<'_> {
     fn from(value: MlColor) -> Self {
         Self::Color(value.0)
     }

--- a/galileo-maplibre/src/style/expression.rs
+++ b/galileo-maplibre/src/style/expression.rs
@@ -806,14 +806,14 @@ impl MlExpr {
             })
         }
 
-        fn literal(v: &Value) -> Option<ExprValue<String>> {
+        fn literal(v: &Value) -> Option<ExprValue<'static>> {
             match v {
                 Value::Bool(v) => Some(ExprValue::Boolean(*v)),
                 Value::Number(v) => Some(ExprValue::Number(v.as_f64()?)),
                 Value::String(v) => Some(
                     parse_css_color(v)
                         .map(ExprValue::from)
-                        .unwrap_or_else(|| ExprValue::String(v.clone())),
+                        .unwrap_or_else(|| ExprValue::String(v.clone().into())),
                 ),
                 Value::Null => Some(ExprValue::Null),
                 _ => None,

--- a/galileo-maplibre/src/style/layer/line.rs
+++ b/galileo-maplibre/src/style/layer/line.rs
@@ -48,7 +48,7 @@ pub struct LinePaint {
 
     /// Dash pattern for the line. Supports expressions.
     #[serde(rename = "line-dasharray", skip_serializing_if = "Option::is_none")]
-    pub line_dasharray: Option<Vec<f32>>,
+    pub line_dasharray: Option<MlStyleValue<Vec<f64>>>,
 
     /// Gap width for a casing effect. Supports expressions.
     #[serde(rename = "line-gap-width", skip_serializing_if = "Option::is_none")]

--- a/galileo/src/expr/interpolation.rs
+++ b/galileo/src/expr/interpolation.rs
@@ -17,7 +17,7 @@ pub trait Interpolation {
     fn control_points(&self) -> &[ControlPoint];
     fn interpolate_num(&self, t: f64, x1: f64, out1: f64, x2: f64, out2: f64) -> f64;
 
-    fn eval<'a>(&'a self, f: &'a impl ExprFeature, v: ExprView) -> ExprValue<&'a str> {
+    fn eval<'a>(&'a self, f: &'a impl ExprFeature, v: ExprView) -> ExprValue<'static> {
         let Some(input) = self.input().eval(f, v).as_number() else {
             return ExprValue::Null;
         };
@@ -36,8 +36,8 @@ pub trait Interpolation {
 
         match (lower, upper) {
             (None, None) => ExprValue::Null,
-            (Some(lower), None) => lower.1.eval(f, v),
-            (None, Some(upper)) => upper.1.eval(f, v),
+            (Some(lower), None) => lower.1.eval(f, v).owned(),
+            (None, Some(upper)) => upper.1.eval(f, v).owned(),
             (Some(lower), Some(upper)) => self.interpolate(
                 *input,
                 **lower.0,
@@ -66,14 +66,14 @@ pub trait Interpolation {
         Some(evaluated)
     }
 
-    fn interpolate<T>(
+    fn interpolate(
         &self,
         t: f64,
         x1: f64,
-        out1: ExprValue<T>,
+        out1: ExprValue<'_>,
         x2: f64,
-        out2: ExprValue<T>,
-    ) -> ExprValue<T> {
+        out2: ExprValue<'_>,
+    ) -> ExprValue<'static> {
         match (out1, out2) {
             (ExprValue::Number(out1), ExprValue::Number(out2)) => {
                 self.interpolate_num(t, x1, out1, x2, out2).into()
@@ -81,6 +81,10 @@ pub trait Interpolation {
             (ExprValue::Color(out1), ExprValue::Color(out2)) => {
                 self.interpolate_color(t, x1, out1, x2, out2).into()
             }
+            (ExprValue::NumArray(out1), ExprValue::NumArray(out2)) => self
+                .interpolate_num_array(t, x1, &out1, x2, &out2)
+                .map(|v| v.into())
+                .unwrap_or(ExprValue::Null),
             _ => ExprValue::Null,
         }
     }
@@ -92,6 +96,26 @@ pub trait Interpolation {
         let a = self.interpolate_num(t, x1, out1.a() as f64, x2, out2.a() as f64) as u8;
 
         Color::rgba(r, g, b, a)
+    }
+
+    fn interpolate_num_array(
+        &self,
+        t: f64,
+        x1: f64,
+        out1: &[f64],
+        x2: f64,
+        out2: &[f64],
+    ) -> Option<Vec<f64>> {
+        if out1.is_empty() || out1.len() != out2.len() {
+            return None;
+        }
+
+        let mut result = vec![0.0; out1.len()];
+        for i in 0..out1.len() {
+            result[i] = self.interpolate_num(t, x1, out1[i], x2, out2[i]);
+        }
+
+        Some(result)
     }
 }
 

--- a/galileo/src/expr/match_expr.rs
+++ b/galileo/src/expr/match_expr.rs
@@ -11,12 +11,12 @@ pub struct MatchExpr {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MatchCase {
-    pub in_values: Vec<ExprValue<String>>,
+    pub in_values: Vec<ExprValue<'static>>,
     pub out: Expr,
 }
 
 impl MatchExpr {
-    pub fn eval<'a>(&'a self, f: &'a impl ExprFeature, v: ExprView) -> ExprValue<&'a str> {
+    pub fn eval<'a>(&'a self, f: &'a impl ExprFeature, v: ExprView) -> ExprValue<'a> {
         let input = self.input.eval(f, v);
         let fallback = self.fallback.eval(f, v);
         if input.is_null() {

--- a/galileo/src/expr/mod.rs
+++ b/galileo/src/expr/mod.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)] //TODO: temporary allow
 
+use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use itertools::Itertools;
@@ -50,7 +51,7 @@ pub enum Expr {
     WithOpacity(WithOpacityExpr),
 
     #[serde(untagged)]
-    Literal(ExprValue<String>),
+    Value(ExprValue<'static>),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -63,7 +64,7 @@ pub type BoolExpr = TypedExpr<bool>;
 
 impl<T> Default for TypedExpr<T> {
     fn default() -> Self {
-        Self(Expr::Literal(ExprValue::Null), PhantomData)
+        Self(Expr::Value(ExprValue::Null), PhantomData)
     }
 }
 
@@ -91,6 +92,15 @@ impl TypedExpr<bool> {
     }
 }
 
+impl TypedExpr<Vec<f64>> {
+    pub fn eval<'a>(&'a self, f: &'a impl ExprFeature, v: ExprView) -> Option<Cow<'a, [f64]>> {
+        match self.0.eval(f, v) {
+            ExprValue::NumArray(arr) => Some(arr),
+            _ => None,
+        }
+    }
+}
+
 impl<Out> From<Expr> for TypedExpr<Out> {
     fn from(value: Expr) -> Self {
         Self::new(value)
@@ -99,37 +109,43 @@ impl<Out> From<Expr> for TypedExpr<Out> {
 
 impl From<Color> for TypedExpr<Color> {
     fn from(value: Color) -> Self {
-        Expr::Literal(value.into()).into()
+        Expr::Value(value.into()).into()
     }
 }
 
 impl From<f64> for TypedExpr<f64> {
     fn from(value: f64) -> Self {
-        Expr::Literal(value.into()).into()
+        Expr::Value(value.into()).into()
     }
 }
 
 impl From<Color> for Expr {
     fn from(value: Color) -> Self {
-        Expr::Literal(value.into())
+        Expr::Value(value.into())
     }
 }
 
 impl From<f64> for Expr {
     fn from(value: f64) -> Self {
-        Expr::Literal(value.into())
+        Expr::Value(value.into())
     }
 }
 
 impl From<String> for Expr {
     fn from(value: String) -> Self {
-        Expr::Literal(value.into())
+        Expr::Value(value.into())
     }
 }
 
 impl From<bool> for Expr {
     fn from(value: bool) -> Self {
-        Expr::Literal(value.into())
+        Expr::Value(value.into())
+    }
+}
+
+impl From<Vec<f64>> for Expr {
+    fn from(value: Vec<f64>) -> Self {
+        Expr::Value(value.into())
     }
 }
 
@@ -161,13 +177,13 @@ impl<'de, Out> Deserialize<'de> for TypedExpr<Out> {
 }
 
 pub trait ExprFeature {
-    fn property(&self, property_name: &str) -> ExprValue<&str>;
+    fn property(&self, property_name: &str) -> ExprValue<'_>;
     fn geom_type(&self) -> ExprGeometryType;
 }
 
 pub struct EmptyExprFeature;
 impl ExprFeature for EmptyExprFeature {
-    fn property(&self, _property_name: &str) -> ExprValue<&str> {
+    fn property(&self, _property_name: &str) -> ExprValue<'_> {
         ExprValue::Null
     }
 
@@ -183,9 +199,9 @@ pub struct ExprView {
 }
 
 impl Expr {
-    pub fn eval<'a>(&'a self, f: &'a impl ExprFeature, v: ExprView) -> ExprValue<&'a str> {
+    pub fn eval<'a>(&'a self, f: &'a impl ExprFeature, v: ExprView) -> ExprValue<'a> {
         match self {
-            Expr::Literal(x) => x.borrowed(),
+            Expr::Value(x) => x.borrowed(),
             Expr::All(exprs) => exprs.iter().all(|expr| expr.eval(f, v).to_bool()).into(),
             Expr::Any(exprs) => exprs.iter().any(|expr| expr.eval(f, v).to_bool()).into(),
             Expr::Not(expr) => (!expr.eval(f, v).to_bool()).into(),
@@ -218,9 +234,9 @@ impl Expr {
     }
 }
 
-impl From<ExprValue<String>> for Expr {
-    fn from(value: ExprValue<String>) -> Self {
-        Self::Literal(value)
+impl From<ExprValue<'static>> for Expr {
+    fn from(value: ExprValue<'static>) -> Self {
+        Self::Value(value)
     }
 }
 
@@ -231,7 +247,7 @@ pub struct WithOpacityExpr {
 }
 
 impl WithOpacityExpr {
-    pub fn eval<'a>(&'a self, f: &'a impl ExprFeature, v: ExprView) -> ExprValue<&'a str> {
+    pub fn eval<'a>(&'a self, f: &'a impl ExprFeature, v: ExprView) -> ExprValue<'a> {
         let Some(color) = self.color.eval(f, v).as_color() else {
             return ExprValue::Null;
         };
@@ -258,7 +274,7 @@ mod tests {
             expr.0,
             Expr::Eq(
                 Box::new(Expr::Get("kind".to_string())),
-                Box::new(Expr::Literal(ExprValue::String("road".to_string()))),
+                Box::new(Expr::Value("road".to_string().into())),
             )
         );
     }
@@ -267,7 +283,7 @@ mod tests {
     fn deserialize_expr_from_num() {
         let json = "42";
         let expr: NumExpr = serde_json::from_str(json).unwrap();
-        assert_eq!(expr.0, Expr::Literal(ExprValue::Number(42.0)));
+        assert_eq!(expr.0, Expr::Value(ExprValue::Number(42.0)));
     }
 
     #[test]

--- a/galileo/src/expr/parser.rs
+++ b/galileo/src/expr/parser.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use chumsky::error::Rich;
 use chumsky::prelude::*;
 
@@ -37,22 +35,12 @@ fn atom<'src>(
     choice((
         block(expr_parser.clone()),
         literal(),
+        num_array(),
         func_call(expr_parser),
         property(),
         invalid(),
     ))
     .boxed()
-}
-
-fn func0(func_name: &str, constructor: Expr, args: Vec<Expr>) -> Result<Expr, String> {
-    if !args.is_empty() {
-        return Err(format!(
-            "Function `{func_name}` expected 0 arguments, but got {}",
-            args.len()
-        ));
-    }
-
-    Ok(constructor)
 }
 
 struct FuncContext<'src> {
@@ -174,7 +162,7 @@ macro_rules! impl_get_arg {
 impl_get_arg!(Box<Expr>, FuncArgument::Expression(v) => Box::new(v), "Expression");
 impl_get_arg!(
     String,
-    FuncArgument::Expression(Expr::Literal(ExprValue::String(v))) => v,
+    FuncArgument::Expression(Expr::Value(ExprValue::String(v))) => v.to_string(),
     "String"
 );
 impl_get_arg!(Vec<Expr>, FuncArgument::Array(v) => v, "Expression Array");
@@ -183,7 +171,6 @@ impl_get_arg!(Vec<Expr>, FuncArgument::Array(v) => v, "Expression Array");
 enum FuncArgument {
     Expression(Expr),
     Array(Vec<Expr>),
-    Tuple(Vec<Expr>),
 }
 
 fn func_arg<'src>(
@@ -199,15 +186,17 @@ fn func_arg<'src>(
         .delimited_by(just('['), just(']'))
         .map(FuncArgument::Array);
 
-    let tuple = expr_parser
+    choice((array, expr)).padded()
+}
+
+fn num_array<'src>() -> impl Parser<'src, &'src str, Expr, Error<'src>> {
+    number()
+        .padded()
         .separated_by(just(','))
-        .at_least(2)
         .allow_trailing()
         .collect::<Vec<_>>()
-        .delimited_by(just('('), just(')'))
-        .map(FuncArgument::Tuple);
-
-    choice((array, tuple, expr)).padded()
+        .delimited_by(just('['), just(']'))
+        .map(|v| ExprValue::NumArray(v.into()).into())
 }
 
 fn func_call<'src>(
@@ -295,7 +284,7 @@ fn ident_cont<'src>() -> impl Parser<'src, &'src str, char, extra::Err<Rich<'src
 
 /// Parses `true` or `false`, rejecting a longer identifier that merely starts with those words.
 fn bool_literal<'src>()
--> impl Parser<'src, &'src str, ExprValue<String>, extra::Err<Rich<'src, char>>> {
+-> impl Parser<'src, &'src str, ExprValue<'static>, extra::Err<Rich<'src, char>>> {
     let true_ = just("true").to(ExprValue::Boolean(true));
     let false_ = just("false").to(ExprValue::Boolean(false));
 
@@ -304,13 +293,13 @@ fn bool_literal<'src>()
 
 /// Parses `null`, rejecting a longer identifier that merely starts with `null`.
 fn null_literal<'src>()
--> impl Parser<'src, &'src str, ExprValue<String>, extra::Err<Rich<'src, char>>> {
+-> impl Parser<'src, &'src str, ExprValue<'static>, extra::Err<Rich<'src, char>>> {
     just("null").to(ExprValue::Null)
 }
 
 /// Parses a hex color literal: `#RRGGBB` or `#RRGGBBAA`.
 fn hex_color_literal<'src>()
--> impl Parser<'src, &'src str, ExprValue<String>, extra::Err<Rich<'src, char>>> {
+-> impl Parser<'src, &'src str, ExprValue<'static>, extra::Err<Rich<'src, char>>> {
     just('#')
         .ignore_then(
             any()
@@ -343,7 +332,7 @@ fn invalid<'src>() -> impl Parser<'src, &'src str, Expr, Error<'src>> {
         })
 }
 
-fn number_literal<'src>() -> impl Parser<'src, &'src str, ExprValue<String>, Error<'src>> {
+fn number<'src>() -> impl Parser<'src, &'src str, f64, Error<'src>> {
     let digits = text::digits(10);
 
     let fraction = just('.').then(digits.or_not()).or_not();
@@ -357,11 +346,11 @@ fn number_literal<'src>() -> impl Parser<'src, &'src str, ExprValue<String>, Err
         .then(fraction)
         .then(exponent)
         .to_slice()
-        .try_map(|s: &str, span| {
-            s.parse::<f64>()
-                .map(ExprValue::Number)
-                .map_err(|e| Rich::custom(span, e))
-        })
+        .try_map(|s: &str, span| s.parse::<f64>().map_err(|e| Rich::custom(span, e)))
+}
+
+fn number_literal<'src>() -> impl Parser<'src, &'src str, ExprValue<'static>, Error<'src>> {
+    number().map(ExprValue::Number)
 }
 
 /// Parses a quoted string literal. Both `"hello"` and `'hello'` are accepted; the opening and
@@ -388,7 +377,7 @@ fn literal<'src>() -> impl Parser<'src, &'src str, Expr, Error<'src>> {
         string_literal().map(ExprValue::from),
     ))
     .padded()
-    .map(Expr::Literal)
+    .map(Expr::Value)
     .then_ignore(atom_boundary().rewind())
     .labelled("literal")
 }
@@ -483,6 +472,10 @@ mod tests {
                 },
             ),
             ("geom_type()", Expr::GeomType),
+            (
+                "[1, 2, 3]",
+                Expr::Value(ExprValue::NumArray((&[1.0, 2.0, 3.0]).into())),
+            ),
         ];
 
         for (case, expected) in cases {
@@ -507,7 +500,7 @@ mod tests {
 
     #[test]
     fn parse_block() {
-        check("(42)", Expr::Literal(42.0.into()));
+        check("(42)", Expr::Value(42.0.into()));
         check(
             "(42 == 12)",
             Expr::Eq(Box::new(42.0.into()), Box::new(12.0.into())),
@@ -582,7 +575,7 @@ mod tests {
 
     #[test]
     fn parser_error_unclosed_bracket() {
-        ass!(s("zoom("), @r#""found end of input at 5..5 expected ''['', ''('', expression block, literal, any, property name, or '')''""#);
+        ass!(s("zoom("), @r#""found end of input at 5..5 expected ''['', expression block, literal, any, property name, or '')''""#);
     }
 
     #[test]

--- a/galileo/src/expr/value.rs
+++ b/galileo/src/expr/value.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 use crate::Color;
@@ -12,18 +14,19 @@ pub enum ExprGeometryType {
     MultiPolygon,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum ExprValue<S> {
+pub enum ExprValue<'a> {
     Null,
     Boolean(bool),
     Number(f64),
     Color(Color),
-    String(S),
+    String(Cow<'a, str>),
     GeomType(ExprGeometryType),
+    NumArray(Cow<'a, [f64]>),
 }
 
-impl<S> ExprValue<S> {
+impl ExprValue<'_> {
     pub fn as_bool(&self) -> Option<bool> {
         match self {
             ExprValue::Boolean(v) => Some(*v),
@@ -59,52 +62,69 @@ impl<S> ExprValue<S> {
     pub fn is_null(&self) -> bool {
         matches!(self, Self::Null)
     }
-}
 
-impl ExprValue<String> {
-    pub(super) fn borrowed(&self) -> ExprValue<&str> {
+    pub fn borrowed<'a>(&'a self) -> ExprValue<'a> {
         match self {
             ExprValue::Null => ExprValue::Null,
             ExprValue::Boolean(v) => ExprValue::Boolean(*v),
             ExprValue::Number(v) => ExprValue::Number(*v),
             ExprValue::Color(v) => ExprValue::Color(*v),
-            ExprValue::String(v) => ExprValue::String(v),
+            ExprValue::String(cow) => ExprValue::String(Cow::Borrowed(cow)),
             ExprValue::GeomType(v) => ExprValue::GeomType(*v),
+            ExprValue::NumArray(cow) => ExprValue::NumArray(Cow::Borrowed(cow)),
+        }
+    }
+
+    pub fn owned(&self) -> ExprValue<'static> {
+        match self {
+            ExprValue::Null => ExprValue::Null,
+            ExprValue::Boolean(v) => ExprValue::Boolean(*v),
+            ExprValue::Number(v) => ExprValue::Number(*v),
+            ExprValue::Color(v) => ExprValue::Color(*v),
+            ExprValue::String(cow) => ExprValue::String(Cow::Owned(cow.to_string())),
+            ExprValue::GeomType(v) => ExprValue::GeomType(*v),
+            ExprValue::NumArray(cow) => ExprValue::NumArray(Cow::Owned(cow.to_vec())),
         }
     }
 }
 
-impl<S> From<bool> for ExprValue<S> {
+impl From<bool> for ExprValue<'_> {
     fn from(value: bool) -> Self {
         Self::Boolean(value)
     }
 }
 
-impl<S> From<f64> for ExprValue<S> {
+impl From<f64> for ExprValue<'_> {
     fn from(value: f64) -> Self {
         Self::Number(value)
     }
 }
 
-impl<S> From<ExprGeometryType> for ExprValue<S> {
+impl From<ExprGeometryType> for ExprValue<'_> {
     fn from(value: ExprGeometryType) -> Self {
         Self::GeomType(value)
     }
 }
 
-impl<S> From<Color> for ExprValue<S> {
+impl From<Color> for ExprValue<'_> {
     fn from(value: Color) -> Self {
         Self::Color(value)
     }
 }
 
-impl From<String> for ExprValue<String> {
+impl From<String> for ExprValue<'_> {
     fn from(value: String) -> Self {
-        Self::String(value)
+        Self::String(value.into())
     }
 }
 
-impl<S: PartialOrd> PartialOrd for ExprValue<S> {
+impl From<Vec<f64>> for ExprValue<'_> {
+    fn from(value: Vec<f64>) -> Self {
+        Self::NumArray(value.into())
+    }
+}
+
+impl PartialOrd for ExprValue<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match (self, other) {
             (ExprValue::Boolean(v1), ExprValue::Boolean(v2)) => v1.partial_cmp(v2),

--- a/galileo/src/layer/vector_tile_layer/style.rs
+++ b/galileo/src/layer/vector_tile_layer/style.rs
@@ -1,11 +1,13 @@
 //! See [`VectorTileStyle`].
 
+use std::borrow::Cow;
+
 use galileo_mvt::{MvtFeature, MvtValue};
 use serde::{Deserialize, Serialize};
 
 use crate::Color;
 use crate::expr::{
-    BoolExpr, ColorExpr, ExprFeature, ExprGeometryType, ExprValue, ExprView, NumExpr,
+    BoolExpr, ColorExpr, ExprFeature, ExprGeometryType, ExprValue, ExprView, NumExpr, TypedExpr,
 };
 use crate::render::point_paint::PointPaint;
 use crate::render::text::{
@@ -61,7 +63,7 @@ impl StyleRule {
 }
 
 impl ExprFeature for MvtFeature {
-    fn property(&self, property_name: &str) -> crate::expr::ExprValue<&str> {
+    fn property(&self, property_name: &str) -> ExprValue<'_> {
         self.properties
             .get(property_name)
             .map(|v| v.into())
@@ -77,10 +79,10 @@ impl ExprFeature for MvtFeature {
     }
 }
 
-impl<'a> From<&'a MvtValue> for ExprValue<&'a str> {
+impl<'a> From<&'a MvtValue> for ExprValue<'a> {
     fn from(value: &'a MvtValue) -> Self {
         match value {
-            MvtValue::String(v) => Self::String(v),
+            MvtValue::String(v) => Self::String(Cow::Borrowed(v)),
             MvtValue::Float(v) => Self::Number(*v as f64),
             MvtValue::Double(v) => Self::Number(*v),
             MvtValue::Int64(v) => Self::Number(*v as f64),
@@ -176,17 +178,21 @@ pub struct VectorTileLineSymbol {
     ///
     /// Sets length of "dash - gap - dash - ..." of widths of the line. If the specification contains not even number of
     /// values, the whole pattern is repeated twice when applied.
-    pub dasharray: Option<Vec<f32>>,
+    pub dasharray: Option<TypedExpr<Vec<f64>>>,
 }
 
 impl VectorTileLineSymbol {
-    pub(crate) fn to_paint(&self, feature: &MvtFeature, view: ExprView) -> Option<LinePaint<'_>> {
+    pub(crate) fn to_paint<'a>(
+        &'a self,
+        feature: &'a MvtFeature,
+        view: ExprView,
+    ) -> Option<LinePaint<'a>> {
         Some(LinePaint {
             color: self.stroke_color.eval(feature, view)?,
             width: self.width.eval(feature, view)?,
             offset: 0.0,
             line_cap: LineCap::Butt,
-            dasharray: self.dasharray.as_deref(),
+            dasharray: self.dasharray.as_ref().and_then(|v| v.eval(feature, view)),
         })
     }
 }

--- a/galileo/src/layer/vector_tile_layer/tile_provider/vt_processor.rs
+++ b/galileo/src/layer/vector_tile_layer/tile_provider/vt_processor.rs
@@ -198,7 +198,7 @@ impl VtProcessor {
 
     fn get_line_symbol<'a>(
         rule: &'a StyleRule,
-        feature: &MvtFeature,
+        feature: &'a MvtFeature,
         view: ExprView,
     ) -> Option<LinePaint<'a>> {
         rule.symbol.line().and_then(|s| s.to_paint(feature, view))

--- a/galileo/src/render/mod.rs
+++ b/galileo/src/render/mod.rs
@@ -5,6 +5,7 @@
 //! At this point only [`WgpuRenderer`] is implemented.
 
 use std::any::Any;
+use std::borrow::Cow;
 
 use galileo_types::cartesian::{Size, Vector2};
 use maybe_sync::{MaybeSend, MaybeSync};
@@ -117,7 +118,7 @@ pub struct LinePaint<'a> {
     ///
     /// Sets length of "dash - gap - dash - ..." of widths of the line. If the specification contains not even number of
     /// values, the whole pattern is repeated twice when applied.
-    pub dasharray: Option<&'a [f32]>,
+    pub dasharray: Option<Cow<'a, [f64]>>,
 }
 
 impl LinePaint<'_> {

--- a/galileo/src/render/render_bundle/world_set.rs
+++ b/galileo/src/render/render_bundle/world_set.rs
@@ -64,7 +64,7 @@ pub(crate) struct LineParameters {
     pub(crate) cap: LineCap,
 }
 
-pub(crate) struct DashArray<'a>(pub(crate) &'a [f32]);
+pub(crate) struct DashArray<'a>(pub(crate) &'a [f64]);
 
 impl WorldRenderSet {
     pub fn new(dpi_scale_factor: f32) -> Self {
@@ -268,7 +268,7 @@ impl WorldRenderSet {
             return;
         }
 
-        let total_pattern_len = pattern.iter().sum::<f32>() * paint.width;
+        let total_pattern_len = pattern.iter().sum::<f64>() as f32 * paint.width;
         if total_pattern_len <= MIN_PATTERN_LENGTH {
             // If pattern is too short, the result looks exactly the same as a continuous line, but
             // computations required are much higher. So we just render a line without dashes.
@@ -282,7 +282,7 @@ impl WorldRenderSet {
 
         let mut pattern_index = 0usize;
         let mut is_dash = true;
-        let mut remaining_in_segment = pattern[0] * paint.width;
+        let mut remaining_in_segment = pattern[0] as f32 * paint.width;
         let mut current_dash: Vec<Point3<f32>> = vec![];
 
         for (from, to) in line.iter_points_closing().tuple_windows() {
@@ -340,7 +340,7 @@ impl WorldRenderSet {
 
                     pattern_index = (pattern_index + 1) % pattern.len();
                     is_dash = !is_dash;
-                    remaining_in_segment = pattern[pattern_index] * paint.width;
+                    remaining_in_segment = pattern[pattern_index] as f32 * paint.width;
                 }
             }
         }


### PR DESCRIPTION
Dasharray property of line styles can now be set using expressions, e.g. select parameters of dashes based on zoom level or even interpolate them between the levels.