### PR TITLE
chore: Decode ML label placement

### DIFF
--- a/galileo-maplibre/src/layer/vector_tile.rs
+++ b/galileo-maplibre/src/layer/vector_tile.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 
 use crate::layer::{UNSUPPORTED, log_unsupported_field};
 use crate::style::color::MlColor;
+use crate::style::layer::symbol::SymbolPlacement;
 use crate::style::layer::{FillLayer, Layer as MaplibreStyleLayer, LineLayer, SymbolLayer};
 use crate::style::source::{TileScheme, VectorSource};
 use crate::style::value::{FunctionStop, FunctionType, MlStyleValue};
@@ -271,7 +272,6 @@ fn symbol_rule(symbol: &SymbolLayer, tile_schema: &TileSchema) -> Option<StyleRu
     )?;
 
     let (font_family, weight, font_style) = parse_ml_fonts(&symbol.layout.text_font);
-    dbg!(&font_color);
 
     let style = VtTextStyle {
         font_family,
@@ -295,16 +295,25 @@ fn symbol_rule(symbol: &SymbolLayer, tile_schema: &TileSchema) -> Option<StyleRu
         outline_color: outline_color.into(),
     };
 
-    Some(StyleRule {
-        layer_name: Some(source_layer),
-        symbol: VectorTileSymbol::Label(VectorTileLabelSymbol {
-            pattern: symbol.layout.text_field.clone().unwrap_or_default(),
-            text_style: style,
+    match symbol.layout.symbol_placement {
+        Some(SymbolPlacement::Point) | None => Some(StyleRule {
+            layer_name: Some(source_layer),
+            symbol: VectorTileSymbol::Label(VectorTileLabelSymbol {
+                pattern: symbol.layout.text_field.clone().unwrap_or_default(),
+                text_style: style,
+            }),
+            min_resolution,
+            max_resolution,
+            filter: filter.map(Into::into),
         }),
-        min_resolution,
-        max_resolution,
-        filter: filter.map(Into::into),
-    })
+        Some(SymbolPlacement::Line) | Some(SymbolPlacement::LineCenter) => {
+            log::debug!(
+                "{UNSUPPORTED} Placing labels along lines is not supported yet. Layer '{}' is skipped.",
+                symbol.id
+            );
+            None
+        }
+    }
 }
 
 /// Parses Maplibre `text-font` entries into a font family list, [`FontWeight`], and [`FontStyle`].

--- a/galileo-maplibre/src/style/layer/symbol.rs
+++ b/galileo-maplibre/src/style/layer/symbol.rs
@@ -140,6 +140,20 @@ impl Default for SymbolPaint {
     }
 }
 
+/// Rule for placing a a text or symbol label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub enum SymbolPlacement {
+    /// At position of a point geometry.
+    #[serde(rename = "point")]
+    Point,
+    /// Along a line.
+    #[serde(rename = "line")]
+    Line,
+    /// At a center point of line or polygon geometry.
+    #[serde(rename = "line-center")]
+    LineCenter,
+}
+
 /// Layout properties for a `symbol` layer.
 #[derive(Debug, Clone, PartialEq, Deserialize, Default)]
 pub struct SymbolLayout {
@@ -149,7 +163,7 @@ pub struct SymbolLayout {
 
     /// Label placement relative to its geometry. Supports expressions.
     #[serde(rename = "symbol-placement", skip_serializing_if = "Option::is_none")]
-    pub symbol_placement: Option<Value>,
+    pub symbol_placement: Option<SymbolPlacement>,
 
     /// Distance between two symbol anchors. Supports expressions.
     #[serde(rename = "symbol-spacing", skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Decode the symbol-placement value and notify that line labels are not supported yet.